### PR TITLE
Added the ability to send an email (once a day) for bad credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ settings:
   remove_obsolete: false
   # Verbosity of messages: optional, default: false
   verbose: false
+smtp:
+  # If you want to recieve email notifications about expired/missing 2FA credentials then uncommend
+  # email: user@test.com
+  # password:
+  # host: smtp.test.com
+  # port: 587
+  # If your email provider doesn't handle TLS
+  # no_tls: true
 filters:
   # Paths to be 'included' in syncing iCloud drive content
   folders:

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ settings:
   # verbose
   verbose: false
 smtp:
-  # If you want to recieve email notifications about expired/missing 2FA credentials then uncommend
+  # If you want to recieve email notifications about expired/missing 2FA credentials then uncomment
   # email: user@test.com
   # password:
   # host: smtp.test.com

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,14 @@ settings:
   destination: './drive'
   # verbose
   verbose: false
+smtp:
+  # If you want to recieve email notifications about expired/missing 2FA credentials then uncommend
+  # email: user@test.com
+  # password:
+  # host: smtp.test.com
+  # port: 587
+  # If your email provider doesn't handle TLS
+  # no_tls: true
 filters:
   # File filters to be included in syncing iCloud drive content
   folders:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/picklepete/pyicloud#68566dc3a51211ef379422c549119b2bf8903b63
 ruamel.yaml==0.16.12
+mailer==0.8.1

--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -71,3 +71,42 @@ def get_verbose(config):
         verbose = config['settings']['verbose']
         print('Enabled verbose ...')
     return verbose
+
+def get_smtp_email(config):
+    email = None
+    if (config and 'smtp' in config and 'email' in config['smtp']):
+        email = config['smtp']['email']
+    return email
+
+def get_smtp_host(config):
+    host = None
+    if not (config and 'smtp' in config and 'host' in config['smtp']):
+        print('Warning: host is not found in config > smtp')
+    else:
+        host = config['smtp']['host']
+    return host
+
+def get_smtp_port(config):
+    port = None
+    if not (config and 'smtp' in config and 'port' in config['smtp']):
+        print('Warning: port is not found in config > smtp')
+    else:
+        port = config['smtp']['port']
+    return port
+
+def get_smtp_password(config):
+    password = None
+    if not (config and 'smtp' in config and 'password' in config['smtp']):
+        print('Warning: password is not found in config > smtp')
+    else:
+        password = config['smtp']['password']
+    return password
+
+
+def get_smtp_no_tls(config):
+    no_tls = False
+    if not (config and 'smtp' in config and 'no_tls' in config['smtp']):
+        print('Warning: no_tls is not found in config > smtp')
+    else:
+        no_tls = config['smtp']['no_tls']
+    return no_tls

--- a/src/notify.py
+++ b/src/notify.py
@@ -1,0 +1,56 @@
+""" Send an email if the 2FA is expired  """
+
+import smtplib
+import datetime
+import logging
+from src import config_parser
+
+def send(config, last_send=None, dry_run=False):
+    sent_on = None
+    email    = config_parser.get_smtp_email(config=config)
+    host     = config_parser.get_smtp_host(config=config)
+    port     = config_parser.get_smtp_port(config=config)
+    no_tls   = config_parser.get_smtp_no_tls(config=config)
+    password = config_parser.get_smtp_password(config=config)
+
+    if (last_send and last_send > datetime.datetime.now()-datetime.timedelta(hours=24)):
+        print("Throttling email to once a day")
+        sent_on = last_send
+    elif email and host and port and password:
+        try:
+            sent_on = datetime.datetime.now()
+            if not dry_run:
+                smtp = smtplib.SMTP(host, port)
+                smtp.set_debuglevel(0)
+                smtp.connect(host, port)
+                if not no_tls:
+                    smtp.starttls()
+
+                if password:
+                    smtp.login(email, password)
+
+                subject = "icloud-drive-docker: Two step authentication required"
+                date = sent_on.strftime("%d/%m/%Y %H:%M")
+
+                message_body ="""Two-step authentication for iCloud Drive (Docker) is required.
+        Please login to your server and authenticate.  Eg:
+        `docker exec -it icloud-drive /bin/sh -c "icloud --username=<icloud-username>"`."""
+
+                msg = "From: %s\nTo: %s\nSubject: %s\nDate: %s\n\n%s" % (
+                    "icloud-drive-docker <" + email + ">",
+                    email,
+                    subject,
+                    date,
+                    message_body
+                )
+
+                smtp.sendmail(email, email, msg)
+                smtp.quit()
+        except (Exception) as e:
+            sent_on = None
+            print("Error: failed to send email:" + str(e))
+            logging.exception(e)
+    else:
+        print("Not sending 2FA notification because SMTP is not configured")
+
+    return sent_on

--- a/src/sync.py
+++ b/src/sync.py
@@ -10,6 +10,7 @@ from shutil import copyfileobj, rmtree
 from pyicloud import PyiCloudService, utils, exceptions
 
 from src import config_parser
+from src import notify
 
 
 def wanted_file(filters, file_path, verbose=False):
@@ -147,6 +148,7 @@ def sync_directory(drive, destination_path, items, root, top=True, filters=None,
 
 
 def sync_drive():
+    last_send = None
     while True:
         config = config_parser.read_config()
         verbose = config_parser.get_verbose(config=config)
@@ -161,7 +163,9 @@ def sync_drive():
                                    remove=config_parser.get_remove_obsolete(config=config), verbose=verbose)
                 else:
                     print('Error: 2FA is required. Please log in.')
+                    last_send = notify.send(config, last_send)
             except exceptions.PyiCloudNoStoredPasswordAvailableException:
+
                 print('password is not stored in keyring. Please save the password in keyring.')
         sleep_for = config_parser.get_sync_interval(config=config)
         next_sync = (datetime.datetime.now() +

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -99,3 +99,47 @@ class TestConfigParser(unittest.TestCase):
         self.assertFalse(config_parser.get_verbose(config=config))
         del config['settings']
         self.assertFalse(config_parser.get_verbose(config=config))
+
+    def test_get_smtp_no_tls(self):
+        config = {'smtp':{'no_tls':True}}
+        self.assertTrue(config_parser.get_smtp_no_tls(config=config))
+        config = {'smtp':{'no_tls':False}}
+        self.assertFalse(config_parser.get_smtp_no_tls(config=config))
+        del config['smtp']['no_tls']
+        self.assertFalse(config_parser.get_smtp_no_tls(config=config))
+
+    def test_get_smtp_email_valids(self):
+        # Given email
+        config = {'smtp':{'email':'user@test.com'}}
+        self.assertEqual(config['smtp']['email'], config_parser.get_smtp_email(config=config))
+
+    def test_smtp_email_invalids(self):
+        config = config_parser.read_config()
+        self.assertIsNone(config_parser.get_smtp_email(config=None))
+
+    def test_get_smtp_host_valids(self):
+        # Given host
+        config = {'smtp':{'host':'smtp.test.com'}}
+        self.assertEqual(config['smtp']['host'], config_parser.get_smtp_host(config=config))
+
+    def test_smtp_host_invalids(self):
+        config = config_parser.read_config()
+        self.assertIsNone(config_parser.get_smtp_host(config=None))
+
+    def test_get_smtp_port_valids(self):
+        # Given port
+        config = {'smtp':{'port':'587'}}
+        self.assertEqual(config['smtp']['port'], config_parser.get_smtp_port(config=config))
+
+    def test_smtp_port_invalids(self):
+        config = config_parser.read_config()
+        self.assertIsNone(config_parser.get_smtp_port(config=None))
+
+    def test_get_smtp_password_valids(self):
+        # Given password
+        config = {'smtp':{'password':'password'}}
+        self.assertEqual(config['smtp']['password'], config_parser.get_smtp_password(config=config))
+
+    def test_smtp_password_invalids(self):
+        config = config_parser.read_config()
+        self.assertIsNone(config_parser.get_smtp_password(config=None))

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -2,6 +2,8 @@ import os
 import unittest
 import datetime
 
+from unittest.mock import patch, call
+from mailer import Message
 from src import config_parser
 from src import notify
 
@@ -26,10 +28,39 @@ class TestNotify(unittest.TestCase):
     def test_no_smtp_config(self):
         # None is returned if email didn't send because of missing config
         self.assertIsNone(notify.send({}, None, dry_run=True))
-        
+
     def test_dry_run_send(self):
         # send returns the datetime of the request
         self.assertIsInstance(notify.send(self.config, None, dry_run=True), datetime.datetime)
 
+    def test_build_message(self):
+        msg = notify.build_message(self.config['smtp']['email'])
+        self.assertEqual(msg.To, self.config['smtp']['email'])
+        self.assertIn(self.config['smtp']['email'], msg.From)
+        self.assertIn('icloud-drive-docker: Two step authentication required', msg.Subject)
+        self.assertIn('Two-step authentication for iCloud Drive (Docker) is required.', msg.Body)
+        self.assertIsInstance(msg, Message)
 
+    def test_send(self):
+        with patch("smtplib.SMTP") as smtp:
+            notify.send(self.config)
+
+            instance = smtp.return_value
+
+            # verify that sendmail() was called
+            self.assertTrue(instance.sendmail.called)
+            self.assertEqual(instance.sendmail.call_count, 1)
+
+            # verify that the correct email is being sent to sendmail()
+            self.assertEqual(config_parser.get_smtp_email(config=self.config), instance.sendmail.mock_calls[0][1][1])
+            # verify that the message was passed to sendmail()
+            self.assertIn('Subject: icloud-drive-docker: Two step authentication required', instance.sendmail.mock_calls[0][1][2])
+
+    def test_send_fail(self):
+        with patch("smtplib.SMTP") as smtp:
+            smtp.side_effect = Exception
+
+            # Verify that a failure doesn't return a send_on timestamp
+            sent_on = notify.send(self.config)
+            self.assertEquals(None, sent_on)
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+import datetime
+
+from src import config_parser
+from src import notify
+
+class TestNotify(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config={'smtp':{
+            'email':    'user@test.com',
+            'host':     'smtp.test.com',
+            'port':     '587',
+            'password': 'password',
+        }}
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_throttling(self):
+        not_24_hours = datetime.datetime.now()
+        # if less than 24 hours has passed since last send, then the same
+        # datetime object is returned
+        self.assertEqual(not_24_hours, notify.send(self.config, not_24_hours, dry_run=True))
+
+    def test_no_smtp_config(self):
+        # None is returned if email didn't send because of missing config
+        self.assertIsNone(notify.send({}, None, dry_run=True))
+        
+    def test_dry_run_send(self):
+        # send returns the datetime of the request
+        self.assertIsInstance(notify.send(self.config, None, dry_run=True), datetime.datetime)
+
+
+


### PR DESCRIPTION
I wanted the ability to get a notification if my credentials expire.  

I decided to hard code in the requirement to only send once a day, but that could be moved to a config option pretty easy.

I also waffled on if I wanted to make the getters for the smtp variables chatty like the rest are.  I ended up making them behave similar to how you already have it. 

Let me know if you have any feedback.