### PR TITLE
Fixed missing keys in filter.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ dmypy.json
 src/drive
 allure-results
 allure-report
+.history
+ignore-config.yaml

--- a/src/sync.py
+++ b/src/sync.py
@@ -189,7 +189,7 @@ def sync_drive():
                 print('password is not stored in keyring. Please save the password in keyring.')
         sleep_for = config_parser.get_sync_interval(config=config)
         next_sync = (datetime.datetime.now() +
-                     datetime.timedelta(seconds=sleep_for)).strftime('%I:%M%p %Z on %b %d, %Y')
+                     datetime.timedelta(seconds=sleep_for)).strftime('%c')
         print(f'Resyncing at {next_sync} ...')
         if sleep_for < 0:
             break

--- a/src/sync.py
+++ b/src/sync.py
@@ -128,20 +128,39 @@ def sync_directory(drive, destination_path, items, root, top=True, filters=None,
         for i in items:
             item = drive[i]
             if item.type == 'folder':
-                new_folder = process_folder(item=item, destination_path=destination_path,
-                                            filters=filters['folders'] if 'folders' in filters else None, root=root,
-                                            verbose=verbose)
+                new_folder = process_folder(
+                    item=item,
+                    destination_path=destination_path,
+                    filters=filters['folders'] if filters and 'folders' in filters else None,
+                    root=root,
+                    verbose=verbose
+                )
                 if not new_folder:
                     continue
                 files.add(new_folder)
-                files.update(sync_directory(drive=item, destination_path=new_folder, items=item.dir(), root=root,
-                                            top=False, filters=filters, verbose=verbose))
+                files.update(sync_directory(
+                    drive=item,
+                    destination_path=new_folder,
+                    items=item.dir(),
+                    root=root,
+                    top=False,
+                    filters=filters,
+                    verbose=verbose
+                ))
             elif item.type == 'file':
-                if wanted_parent_folder(filters=filters['folders'], root=root, folder_path=destination_path,
-                                        verbose=verbose):
-                    process_file(item=item, destination_path=destination_path,
-                                 filters=filters['file_extensions'] if 'file_extensions' in filters else None,
-                                 files=files, verbose=verbose)
+                if wanted_parent_folder(
+                    filters=filters['folders'] if filters and 'folders' in filters else None,
+                    root=root,
+                    folder_path=destination_path,
+                    verbose=verbose
+                ):
+                    process_file(
+                        item=item,
+                        destination_path=destination_path,
+                        filters=filters['file_extensions'] if filters and 'file_extensions' in filters else None,
+                        files=files,
+                        verbose=verbose
+                    )
         if top and remove:
             remove_obsolete(destination_path=destination_path, files=files, verbose=verbose)
     return files
@@ -159,7 +178,8 @@ def sync_drive():
                 api = PyiCloudService(apple_id=username, password=utils.get_password_from_keyring(username=username))
                 if not api.requires_2sa:
                     sync_directory(drive=api.drive, destination_path=destination_path, root=destination_path,
-                                   items=api.drive.dir(), top=True, filters=config['filters'],
+                                   items=api.drive.dir(), top=True,
+                                   filters=config['filters'] if 'filters' in config else None,
                                    remove=config_parser.get_remove_obsolete(config=config), verbose=verbose)
                 else:
                     print('Error: 2FA is required. Please log in.')
@@ -169,7 +189,7 @@ def sync_drive():
                 print('password is not stored in keyring. Please save the password in keyring.')
         sleep_for = config_parser.get_sync_interval(config=config)
         next_sync = (datetime.datetime.now() +
-                     datetime.timedelta(minutes=sleep_for)).strftime('%l:%M%p %Z on %b %d, %Y')
+                     datetime.timedelta(seconds=sleep_for)).strftime('%I:%M%p %Z on %b %d, %Y')
         print(f'Resyncing at {next_sync} ...')
         if sleep_for < 0:
             break

--- a/src/sync.py
+++ b/src/sync.py
@@ -50,7 +50,7 @@ def wanted_parent_folder(filters, root, folder_path, verbose=False):
 
 
 def process_folder(item, destination_path, filters, root, verbose=False):
-    if not (item and destination_path and filters and root):
+    if not (item and destination_path and root):
         return None
     new_directory = os.path.join(destination_path, item.name)
     if not wanted_folder(filters=filters, folder_path=new_directory, root=root, verbose=verbose):

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -2252,6 +2252,25 @@ DRIVE_SUBFOLDER_WORKING = [
     }
 ]
 
+DRIVE_SUBFOLDER_UNWANTED_WORKING = [
+    {
+        'drivewsid': 'FOLDER::com.apple.CloudDocs::1C7F1760-D940-480F-8C4F-005824A4E05C',
+        'docwsid': '1C7F1760-D940-480F-8C4F-005824A4E05C',
+        'zone': 'com.apple.CloudDocs',
+        'name': 'unwanted',
+        'parentId': 'FOLDER::com.apple.CloudDocs::root',
+        'etag': '30',
+        'type': 'FOLDER',
+        'assetQuota': 42199575,
+        'fileCount': 0,
+        'shareCount': 0,
+        'shareAliasCount': 0,
+        'directChildrenCount': 0,
+        'items': [],
+        'numberOfItems': 0,
+    }
+]
+
 DRIVE_FILE_DOWNLOAD_WORKING = {
     'document_id': '516C896C-6AA5-4A30-B30E-5502C2333DAE',
     'data_token': {
@@ -2576,6 +2595,11 @@ class PyiCloudSessionMock(base.PyiCloudSession):
                     == 'FOLDER::com.apple.CloudDocs::D5AA0425-E84F-4501-AF5D-60F1D92648CF'
             ):
                 return ResponseMock(DRIVE_SUBFOLDER_WORKING)
+            if (
+                data[0].get('drivewsid')
+                == 'FOLDER::com.apple.CloudDocs::1C7F1760-D940-480F-8C4F-005824A4E05C'
+            ):
+                return ResponseMock(DRIVE_SUBFOLDER_UNWANTED_WORKING)
         # Drive download
         if 'com.apple.CloudDocs/download/by_id' in url and method == 'GET':
             if params.get('document_id') in ['516C896C-6AA5-4A30-B30E-5502C2333DAE',

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -114,7 +114,6 @@ class TestConfigParser(unittest.TestCase):
         self.assertEqual(config['smtp']['email'], config_parser.get_smtp_email(config=config))
 
     def test_smtp_email_invalids(self):
-        config = config_parser.read_config()
         self.assertIsNone(config_parser.get_smtp_email(config=None))
 
     def test_get_smtp_host_valids(self):
@@ -123,7 +122,6 @@ class TestConfigParser(unittest.TestCase):
         self.assertEqual(config['smtp']['host'], config_parser.get_smtp_host(config=config))
 
     def test_smtp_host_invalids(self):
-        config = config_parser.read_config()
         self.assertIsNone(config_parser.get_smtp_host(config=None))
 
     def test_get_smtp_port_valids(self):
@@ -132,7 +130,6 @@ class TestConfigParser(unittest.TestCase):
         self.assertEqual(config['smtp']['port'], config_parser.get_smtp_port(config=config))
 
     def test_smtp_port_invalids(self):
-        config = config_parser.read_config()
         self.assertIsNone(config_parser.get_smtp_port(config=None))
 
     def test_get_smtp_password_valids(self):
@@ -141,5 +138,4 @@ class TestConfigParser(unittest.TestCase):
         self.assertEqual(config['smtp']['password'], config_parser.get_smtp_password(config=config))
 
     def test_smtp_password_invalids(self):
-        config = config_parser.read_config()
         self.assertIsNone(config_parser.get_smtp_password(config=None))

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,8 +1,7 @@
-import os
 import unittest
 import datetime
 
-from unittest.mock import patch, call
+from unittest.mock import patch
 from mailer import Message
 from src import config_parser
 from src import notify
@@ -42,7 +41,7 @@ class TestNotify(unittest.TestCase):
         self.assertIsInstance(msg, Message)
 
     def test_send(self):
-        with patch("smtplib.SMTP") as smtp:
+        with patch('smtplib.SMTP') as smtp:
             notify.send(self.config)
 
             instance = smtp.return_value
@@ -52,15 +51,22 @@ class TestNotify(unittest.TestCase):
             self.assertEqual(instance.sendmail.call_count, 1)
 
             # verify that the correct email is being sent to sendmail()
-            self.assertEqual(config_parser.get_smtp_email(config=self.config), instance.sendmail.mock_calls[0][1][1])
+            self.assertEqual(
+                config_parser.get_smtp_email(config=self.config),
+                instance.sendmail.mock_calls[0][1][1]
+            )
+
             # verify that the message was passed to sendmail()
-            self.assertIn('Subject: icloud-drive-docker: Two step authentication required', instance.sendmail.mock_calls[0][1][2])
+            self.assertIn(
+                'Subject: icloud-drive-docker: Two step authentication required',
+                instance.sendmail.mock_calls[0][1][2]
+            )
 
     def test_send_fail(self):
-        with patch("smtplib.SMTP") as smtp:
+        with patch('smtplib.SMTP') as smtp:
             smtp.side_effect = Exception
 
             # Verify that a failure doesn't return a send_on timestamp
             sent_on = notify.send(self.config)
-            self.assertEquals(None, sent_on)
+            self.assertEqual(None, sent_on)
 


### PR DESCRIPTION
  I wanted to have all folders synced so I commented out folders in the
  filter and the script broke.

  To fix I just added a test checking if filters wasn't None and the key
  exists

  Another issue I found was the the datetime string for `next_sync` was using minutes instead of seconds, so the text was wrong.  Additionally the strftime was invalid so it wasn't printing at all.  I swapped the `%l` (lowercase L) for `%I` (uppercase i).  I was also thinking I could just swap the whole string with `%c` which should just do a locale appropriate date string. [strftime docs](https://strftime.org/)

  The linter was complaining a bit so I cleaned up a few files so it
  would be happy