### PR TITLE
Moved CI to Github Actions

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu18.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu18.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Travis CI moved to .com from .org. Decided to simplify CI by moving test/coverage phase to Github Actions as well.