### PR TITLE
removed __original from filename for original quality photos; test quality improvements;

### DIFF
--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -6,11 +6,12 @@ from pyicloud import exceptions
 
 
 def generate_file_name(photo, file_size, destination_path, verbose=False):
-    tokens = photo.filename.rsplit(".", 1)
-    tokens.insert(len(tokens) - 1, file_size)
-    return os.path.abspath(
-        os.path.join(destination_path, "__".join(tokens[:-1]) + "." + tokens[-1])
-    )
+    filename = photo.filename
+    if file_size != "original":
+        tokens = photo.filename.rsplit(".", 1)
+        tokens.insert(len(tokens) - 1, file_size)
+        filename = "__".join(tokens[:-1]) + "." + tokens[-1]
+    return os.path.abspath(os.path.join(destination_path, filename))
 
 
 def photo_exists(photo, file_size, local_path, verbose=False):
@@ -75,10 +76,10 @@ def sync_photos(config, photos, verbose):
         sync_album(
             album=photos.all,
             destination_path=os.path.join(destination_path, "all"),
-
             file_sizes=filters["file_sizes"],
             verbose=verbose,
         )
+
 
 # def enable_debug():
 #     import contextlib

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -2703,6 +2703,9 @@ class PyiCloudSessionMock(base.PyiCloudSession):
             or "https://cvws.icloud-content.com/B/ASTSuc7S58IPmVCJIUslbeCRjsno" in url
             or "https://cvws.icloud-content.com/B/ATTRy6p-Q3U1HqcF6BUKrrOMnjvn" in url
             or "https://cvws.icloud-content.com/B/ARZd_GzpY62XRtXt-jP6UsV4fBZH" in url
+            # IMG_3328.JPG
+            or "https://cvws.icloud-content.com/B/EeGlt2PppPTgd0Q7mp8GenIugSh7AQYmx-DRYXnMs0tkDZ3rorp4IB99"
+            in url
         ):
             return ResponseMock(
                 {},
@@ -2714,6 +2717,9 @@ class PyiCloudSessionMock(base.PyiCloudSession):
             or "https://cvws.icloud-content.com/B/AUxVFT2yVsQ5739tmU5c1497duFD" in url
             or "https://cvws.icloud-content.com/B/Ab_8kUAhnGzSxnl9yWvh8JKBpOvV" in url
             or "https://cvws.icloud-content.com/B/AVx3_VKkbWPdNbWw68mrWzSuemXg" in url
+            # IMG_3328.JPG
+            or "https://cvws.icloud-content.com/B/YN1v8eGiHYYZ_aKUkMuGtSf0P1BNAXKVYPcDa-9Mjvnap0ZS-p2Z24V3"
+            in url
         ):
             return ResponseMock(
                 {},
@@ -2727,6 +2733,8 @@ class PyiCloudSessionMock(base.PyiCloudSession):
             or "https://cvws.icloud-content.com/B/ASPVZ_Pft6gIN2VEA_oUbqQzh6Wy" in url
             or "https://cvws.icloud-content.com/B/AQNND5zpteAXnnBP2BmDd0ropjY9" in url
             or "https://cvws.icloud-content.com/B/ARpHiouI3Ib_ziuZYTCiSikohvMY" in url
+            # IMG_3328.JPG
+            or "https://cvws.icloud-content.com/B/DmK0xzSiAUSFrAsYYAvby7QHrMDeAR5TiM9Qko4rHwmoDH1BgNRVZpF4" in url
         ):
             return ResponseMock(
                 {},

--- a/tests/data/photos_data.py
+++ b/tests/data/photos_data.py
@@ -148,7 +148,6 @@ DATA = {
                         },
                     },
                     {
-
                         "recordName": "E803E065-D8A4-4398-DE23-23F8FD0886EB",
                         "recordType": "CPLAlbum",
                         "fields": {
@@ -371,7 +370,7 @@ DATA = {
                             "resJPEGMedRes": {
                                 "value": {
                                     "fileChecksum": "EeGlt2PppPTgd0Q7mp8GenIugSh7",
-                                    "size": 2194253,
+                                    "size": 1074354,
                                     "wrappingKey": "amaCdL9Z+QxfzgD4+aYATg==",
                                     "referenceChecksum": "AQYmx+DRYXnMs0tkDZ3rorp4IB99",
                                     # pylint: disable=C0321
@@ -412,7 +411,7 @@ DATA = {
                             "resJPEGThumbRes": {
                                 "value": {
                                     "fileChecksum": "DmK0xzSiAUSFrAsYYAvby7QHrMDe",
-                                    "size": 2194253,
+                                    "size": 340532,
                                     "wrappingKey": "r7EeA3tyPsWdcECp6X9dHA==",
                                     "referenceChecksum": "AR5TiM9Qko4rHwmoDH1BgNRVZpF4",
                                     # pylint: disable=C0321
@@ -465,7 +464,7 @@ DATA = {
                             "resJPEGMedRes": {
                                 "value": {
                                     "fileChecksum": "NOHzBUr+DdmTaP/SAVglTurWtsen",
-                                    "size": 2194253,
+                                    "size": 1074354,
                                     "wrappingKey": "eqUQfTajfGXgQHbBJh8Qwg==",
                                     "referenceChecksum": "Ab5Vyk36t2jwuON7WSxvon/DvGtK",
                                     # pylint: disable=C0321
@@ -506,7 +505,7 @@ DATA = {
                             "resJPEGThumbRes": {
                                 "value": {
                                     "fileChecksum": "ASy6f/leU1+xkR1aPmQyvYmwHUpE",
-                                    "size": 2194253,
+                                    "size": 340532,
                                     "wrappingKey": "E1zCp4gxgoHQNQHWjS3Wag==",
                                     "referenceChecksum": "ARHOzkI3sbX3SZDmNQgttNJ9DqQa",
                                     # pylint: disable=C0321
@@ -559,7 +558,7 @@ DATA = {
                             "resJPEGMedRes": {
                                 "value": {
                                     "fileChecksum": "ASTSuc7S58IPmVCJIUslbeCRjsno",
-                                    "size": 2194253,
+                                    "size": 1074354,
                                     "wrappingKey": "ysHoAuqERA8H3MadxO6+PA==",
                                     "referenceChecksum": "ASIoOBi88potAS0gE8tfnojuSlrb",
                                     # pylint: disable=C0321
@@ -600,7 +599,7 @@ DATA = {
                             "resJPEGThumbRes": {
                                 "value": {
                                     "fileChecksum": "ASPVZ/Pft6gIN2VEA/oUbqQzh6Wy",
-                                    "size": 2194253,
+                                    "size": 340532,
                                     "wrappingKey": "3EAjgkS2+Mr38eqQFk7C0A==",
                                     "referenceChecksum": "AXd258pYF6LLhmADLoZAumNqI+8M",
                                     # pylint: disable=C0321
@@ -653,7 +652,7 @@ DATA = {
                             "resJPEGMedRes": {
                                 "value": {
                                     "fileChecksum": "ATTRy6p+Q3U1HqcF6BUKrrOMnjvn",
-                                    "size": 2194253,
+                                    "size": 1074354,
                                     "wrappingKey": "pYDpdhqdaL9SAxHilZEj3Q==",
                                     "referenceChecksum": "ATqG89bMsXhtmMRMw009uhyJc/Kh",
                                     # pylint: disable=C0321
@@ -694,7 +693,7 @@ DATA = {
                             "resJPEGThumbRes": {
                                 "value": {
                                     "fileChecksum": "AQNND5zpteAXnnBP2BmDd0ropjY9",
-                                    "size": 2194253,
+                                    "size": 340532,
                                     "wrappingKey": "lxLQBw46n1nvea4s30UY+A==",
                                     "referenceChecksum": "AV2Zh7WygJu74eNWVuuMT4lM8qme",
                                     # pylint: disable=C0321
@@ -747,7 +746,7 @@ DATA = {
                             "resJPEGMedRes": {
                                 "value": {
                                     "fileChecksum": "ARZd/GzpY62XRtXt+jP6UsV4fBZH",
-                                    "size": 2194253,
+                                    "size": 1074354,
                                     "wrappingKey": "dmZqsyvxEA4s3CvifNMApA==",
                                     "referenceChecksum": "ATi6BbOzDuHl6RONNFCub9eqZqSm",
                                     # pylint: disable=C0321
@@ -788,7 +787,7 @@ DATA = {
                             "resJPEGThumbRes": {
                                 "value": {
                                     "fileChecksum": "ARpHiouI3Ib/ziuZYTCiSikohvMY",
-                                    "size": 2194253,
+                                    "size": 340532,
                                     "wrappingKey": "UiIQr3rRvyIcoAz/sxDugQ==",
                                     "referenceChecksum": "ARtMrcvA8cbMefPDnmwSWQwe+mBd",
                                     # pylint: disable=C0321

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -38,7 +38,7 @@ photos:
     albums:
       - "album 2"
       - album-1
-    file_size: # Valid values are [original, medium or thumb]
+    file_sizes: # Valid values are [original, medium or thumb]
       - original
       - medium
       - thumb


### PR DESCRIPTION
- Fixes #42 : removed `__original` suffix from photos filenames for original quality photos
- Various test quality improvements