### PR TITLE
Preventing re-dowload of empty files

### DIFF
--- a/src/sync_drive.py
+++ b/src/sync_drive.py
@@ -108,7 +108,7 @@ def file_exists(item, local_file):
         remote_file_size = item.size
         if (
             local_file_modified_time == remote_file_modified_time
-            and local_file_size == remote_file_size
+            and (local_file_size == remote_file_size or (local_file_size == 0 and remote_file_size == None) or (local_file_size == None and remote_file_size == 0))
         ):
             LOGGER.debug(f"No changes detected. Skipping the file {local_file} ...")
             return True


### PR DESCRIPTION
I found that when empty files have to be synchronised, they are re-downloaded each time.