### PR TITLE
Fix same names of photos, save all albums, fix package with remove_obsolete

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -62,16 +62,16 @@ def sync():
                 )
                 if not api.requires_2sa:
                     if "drive" in config and enable_sync_drive:
-                        LOGGER.info(f"Syncing drive...")
+                        LOGGER.info("Syncing drive...")
                         sync_drive.sync_drive(config=config, drive=api.drive)
-                        LOGGER.info(f"Drive synced")
+                        LOGGER.info("Drive synced")
                         drive_sync_interval = config_parser.get_drive_sync_interval(
                             config=config
                         )
                     if "photos" in config and enable_sync_photos:
-                        LOGGER.info(f"Syncing photos...")
+                        LOGGER.info("Syncing photos...")
                         sync_photos.sync_photos(config=config, photos=api.photos)
-                        LOGGER.info(f"Photos synced")
+                        LOGGER.info("Photos synced")
                         photos_sync_interval = config_parser.get_photos_sync_interval(
                             config=config
                         )

--- a/src/sync.py
+++ b/src/sync.py
@@ -62,12 +62,16 @@ def sync():
                 )
                 if not api.requires_2sa:
                     if "drive" in config and enable_sync_drive:
+                        LOGGER.info(f"Syncing drive...")
                         sync_drive.sync_drive(config=config, drive=api.drive)
+                        LOGGER.info(f"Drive synced")
                         drive_sync_interval = config_parser.get_drive_sync_interval(
                             config=config
                         )
                     if "photos" in config and enable_sync_photos:
+                        LOGGER.info(f"Syncing photos...")
                         sync_photos.sync_photos(config=config, photos=api.photos)
+                        LOGGER.info(f"Photos synced")
                         photos_sync_interval = config_parser.get_photos_sync_interval(
                             config=config
                         )

--- a/src/sync_drive.py
+++ b/src/sync_drive.py
@@ -90,11 +90,12 @@ def package_exists(item, local_package_path):
             )
             return True
         else:
-            LOGGER.debug(
+            LOGGER.info(
                 f"Changes detected: local_modified_time is {local_package_modified_time}, "
                 + f"remote_modified_time is {remote_package_modified_time}, "
                 + f"local_package_size is {local_package_size} and remote_package_size is {remote_package_size}."
             )
+            rmtree(local_package_path)
     else:
         LOGGER.debug(f"Package {local_package_path} does not exist locally.")
     return False
@@ -130,11 +131,13 @@ def process_package(local_file):
     if "application/zip" == magic_object.from_file(filename=local_file):
         archive_file += ".zip"
         os.rename(local_file, archive_file)
+        LOGGER.info(f"Unpacking {archive_file} to {os.path.dirname(archive_file)}")
         unpack_archive(filename=archive_file, extract_dir=os.path.dirname(archive_file))
         os.remove(archive_file)
     elif "application/gzip" == magic_object.from_file(filename=local_file):
         archive_file += ".gz"
         os.rename(local_file, archive_file)
+        LOGGER.info(f"Unpacking {archive_file} to {os.path.dirname(local_file)}")
         with gzip.GzipFile(filename=archive_file, mode="rb") as gz_file:
             with open(file=local_file, mode="wb") as package_file:
                 copyfileobj(gz_file, package_file)
@@ -181,12 +184,18 @@ def process_file(item, destination_path, filters, files):
     if not wanted_file(filters=filters, file_path=local_file):
         return False
     files.add(local_file)
-    if is_package(item=item):
+    item_is_package = is_package(item=item)
+    if item_is_package:
         if package_exists(item=item, local_package_path=local_file):
+            for f in Path(local_file).glob("**/*"):
+                files.add(str(f))
             return False
     elif file_exists(item=item, local_file=local_file):
         return False
     download_file(item=item, local_file=local_file)
+    if item_is_package:
+        for f in Path(local_file).glob("**/*"):
+            files.add(str(f))
     return True
 
 

--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -8,7 +8,7 @@ from icloudpy import exceptions
 
 
 def generate_file_name(photo, file_size, destination_path):
-    name, ext = photo.filename.rsplit('.', 1)
+    name, ext = photo.filename.rsplit(".", 1)
     filename = "{}-{}.{}".format(name, hashlib.sha256(photo.id.encode()).hexdigest()[:8], ext)
     if file_size != "original":
         tokens = photo.filename.rsplit(".", 1)
@@ -99,7 +99,14 @@ def sync_photos(config, photos):
     if filters["albums"]:
         if filters["albums"] == ["*"]:
             for album in photos.albums:
-                if album in ["All Photos", "Time-lapse", "Videos", "Slo-mo", "Bursts", "Panoramas", "Live", "Recently Deleted"]:
+                if album in ["All Photos",
+                             "Time-lapse",
+                             "Videos",
+                             "Slo-mo",
+                             "Bursts",
+                             "Panoramas",
+                             "Live",
+                             "Recently Deleted"]:
                     continue
                 sync_album(
                     album=photos.albums[album],


### PR DESCRIPTION
See issue 98, 99 and 100.

It could be improved by adding hash to filename only when there's conflict.

I skip "All albums" folder because in my case all photos belongs to (at least) one folder.