### PR TITLE
Make use of remove_obsolete config option for photos

### DIFF
--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -125,7 +125,6 @@ def remove_obsolete(destination_path, files):
                 LOGGER.info(f"Removing {local_file} ...")
                 path.unlink(missing_ok=True)
                 removed_paths.add(local_file)
-    # TODO maybe remove empty dirs?
     return removed_paths
 
 


### PR DESCRIPTION
Currently remove_obsolete_files for photos is unused.

Example config (https://github.com/mandarons/icloud-drive-docker/blob/main/config.yaml#L46) shows it.