### PR TITLE
Download all albums, add album name to file name

### DIFF
--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -96,6 +96,16 @@ def get_photos_sync_interval(config):
     return sync_interval
 
 
+def get_photos_all_albums(config):
+    """Return flag to download all albums from config."""
+    download_all = False
+    config_path = ["photos", "all_albums"]
+    if traverse_config_path(config=config, config_path=config_path):
+        download_all = get_config_value(config=config, config_path=config_path)
+        LOGGER.info("Syncing all albums.")
+    return download_all
+
+
 def prepare_root_destination(config):
     """Prepare root destination."""
     LOGGER.debug("Checking root destination ...")

--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -38,14 +38,20 @@ def generate_file_name(photo, file_size, destination_path):
         destination_path,
         f'{"__".join([album_name, name, file_size, base64.urlsafe_b64encode(photo.id.encode()).decode()])}.{extension}',
     )
+    file_size_id_album_name_short_path = os.path.join(
+        destination_path,
+        f'{"__".join([album_name, name, file_size, base64.urlsafe_b64encode(photo.id.encode()).decode()[2:10]])}.{extension}',
+    )
 
     if os.path.isfile(file_path):
-        os.rename(file_path, file_size_id_album_name_path)
+        os.rename(file_path, file_size_id_album_name_short_path)
     if os.path.isfile(file_size_path):
-        os.rename(file_size_path, file_size_id_album_name_path)
+        os.rename(file_size_path, file_size_id_album_name_short_path)
     if os.path.isfile(file_size_id_path):
-        os.rename(file_size_id_path, file_size_id_album_name_path)
-    return file_size_id_album_name_path
+        os.rename(file_size_id_path, file_size_id_album_name_short_path)
+    if os.path.isfile(file_size_id_album_name_path):
+        os.rename(file_size_id_album_name_path, file_size_id_album_name_short_path)
+    return file_size_id_album_name_short_path
 
 
 def photo_exists(photo, file_size, local_path):

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -399,3 +399,21 @@ class TestConfigParser(unittest.TestCase):
         config["app"]["region"] = "china"
         actual = config_parser.get_region(config=config)
         self.assertEqual(actual, "china")
+
+    def test_get_all_albums_empty(self):
+        """Empty all_albums."""
+        config = read_config(config_path=tests.CONFIG_PATH)
+        self.assertFalse(config_parser.get_photos_all_albums(config=config))
+
+    def test_get_all_albums_true(self):
+        """True all_albums."""
+        config = read_config(config_path=tests.CONFIG_PATH)
+        config["photos"]["all_albums"] = True
+        self.assertTrue(config_parser.get_photos_all_albums(config=config))
+
+    def test_get_all_albums_false(self):
+        """False all_albums."""
+        config = read_config(config_path=tests.CONFIG_PATH)
+        config["photos"]["all_albums"] = False
+        self.assertFalse(config_parser.get_photos_all_albums(config=config))
+

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -90,7 +90,7 @@ class TestSyncPhotos(unittest.TestCase):
         os.remove(
             os.path.join(
                 album_1_path,
-                "IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
+                "album-1__IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
             )
         )
         # Download missing file
@@ -104,7 +104,7 @@ class TestSyncPhotos(unittest.TestCase):
                     (
                         s
                         for s in captured[1]
-                        if "album-1/IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG ..."
+                        if "album-1/album-1__IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG ..."
                         in s
                     ),
                     None,
@@ -144,7 +144,7 @@ class TestSyncPhotos(unittest.TestCase):
         os.remove(
             os.path.join(
                 album_1_path,
-                "IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
+                "album-1__IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
             )
         )
         shutil.copyfile(
@@ -161,7 +161,7 @@ class TestSyncPhotos(unittest.TestCase):
                     (
                         s
                         for s in captured[1]
-                        if "album-1/IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG ..."
+                        if "album-1/album-1__IMG_3148__medium__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG ..."
                         in s
                     ),
                     None,
@@ -230,7 +230,7 @@ class TestSyncPhotos(unittest.TestCase):
         os.rename(
             os.path.join(
                 album_1_path,
-                "IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
+                "album-1__IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
             ),
             os.path.join(album_1_path, "IMG_3148.JPG"),
         )
@@ -246,11 +246,37 @@ class TestSyncPhotos(unittest.TestCase):
 
         self.assertFalse(os.path.exists(os.path.join(album_1_path, "IMG_3148.JPG")))
 
+        # Rename previous original files - upgrade to newer version
+        os.rename(
+            os.path.join(
+                album_1_path,
+                "album-1__IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
+            ),
+            os.path.join(album_1_path, "IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG"),
+        )
+
+        with self.assertLogs(logger=LOGGER, level="DEBUG") as captured:
+            self.assertIsNone(
+                sync_photos.sync_photos(config=config, photos=mock_service.photos)
+            )
+            self.assertTrue(len(captured.records) > 0)
+            self.assertIsNone(
+                next((s for s in captured[1] if "Downloading /" in s), None)
+            )
+
+        self.assertFalse(os.path.exists(
+                            os.path.join(
+                                         album_1_path,
+                                         "IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG"
+                                        )
+                            )
+                        )
+
         # Rename previous __original files - upgrade to newer version
         os.rename(
             os.path.join(
                 album_1_path,
-                "IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
+                "album-1__IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
             ),
             os.path.join(album_1_path, "IMG_3148__original.JPG"),
         )
@@ -292,7 +318,7 @@ class TestSyncPhotos(unittest.TestCase):
         os.rename(
             os.path.join(
                 album_1_path,
-                "IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
+                "album-1__IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
             ),
             os.path.join(album_1_path, "delete_me.JPG"),
         )
@@ -329,7 +355,7 @@ class TestSyncPhotos(unittest.TestCase):
         os.rename(
             os.path.join(
                 album_1_path,
-                "IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
+                "album-1__IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG",
             ),
             os.path.join(album_1_path, "delete_me.JPG"),
         )
@@ -381,7 +407,7 @@ class TestSyncPhotos(unittest.TestCase):
                     (
                         s
                         for s in captured[1]
-                        if "all/IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG ..."
+                        if "all/all__IMG_3148__original__QVZ4My9WS2tiV1BkTmJXdzY4bXJXelN1ZW1YZw==.JPG ..."
                         in s
                     ),
                     None,


### PR DESCRIPTION
1) Download all albums recursively if new config option Is set
2) Add album name to filename.
I'm using [photoview](https://github.com/photoview/photoview) to provide online gallery. It uses only filename to identify photos. So if one photo is in multiple albums there's problem. Adding album name to filename solves it.

There's no 100% coverage in unit tests - it requires mocking data for all [Smart Albums](https://github.com/mandarons/icloudpy/blob/main/icloudpy/services/photos.py#L20), I do not know how to do it.