### PR TITLE
[FEATURE] Support all photo sizes from icloudpy in photo filter

### DIFF
--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -3,6 +3,8 @@ __author__ = "Mandar Patil (mandarons@pm.me)"
 
 import os
 
+from icloudpy.services.photos import PhotoAsset
+
 from src import (
     DEFAULT_DRIVE_DESTINATION,
     DEFAULT_PHOTOS_DESTINATION,
@@ -286,7 +288,7 @@ def get_photos_filters(config):
         "file_sizes": ["original"],
         "extensions": None,
     }
-    valid_file_sizes = ["original", "medium", "thumb"]
+    valid_file_sizes = list(PhotoAsset.PHOTO_VERSION_LOOKUP.keys())
     config_path = ["photos", "filters"]
 
     # Check for filters


### PR DESCRIPTION
Instead of using a hardcoded list for the supported photo sizes, refer to the dictionary icloudpy uses internally for mapping readable photo sizes to their iCloud counterparts.

Closes #188.