### PR TITLE
Handle original_alt version extensions

### DIFF
--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -11,6 +11,38 @@ from icloudpy import exceptions
 
 from src import LOGGER, config_parser
 
+original_alt_filetype_to_extension = {
+    "public.png": "png",
+    "public.jpeg": "jpeg",
+    "public.heic": "heic",
+    "public.image": "HEIC",
+    "com.sony.arw-raw-image": "arw",
+    "org.webmproject.webp": "webp",
+    "com.compuserve.gif": "gif",
+    "com.adobe.raw-image": "dng",
+    "public.tiff": "tiff",
+    "public.jpeg-2000": "jp2",
+    "com.truevision.tga-image": "tga",
+    "com.sgi.sgi-image": "sgi",
+    "com.adobe.photoshop-image": "psd",
+    "public.pbm": "pbm",
+    "public.heif": "heif",
+    "com.microsoft.bmp": "bmp",
+    "com.fuji.raw-image": "raf",
+    "com.canon.cr2-raw-image": "cr2",
+    "com.panasonic.rw2-raw-image": "rw2",
+    "com.nikon.nrw-raw-image": "nrw",
+    "com.pentax.raw-image": "pef",
+    "com.nikon.raw-image": "nef",
+    "com.olympus.raw-image": "orf",
+    "com.adobe.pdf": "pdf",
+    "com.canon.cr3-raw-image": "cr3",
+    "com.olympus.or-raw-image": "orf",
+    "public.mpo-image": "mpo",
+    "com.dji.mimo.pano.jpeg": "jpg",
+    "public.avif": "avif",
+    "com.canon.crw-raw-image": "crw",
+}
 
 def photo_wanted(photo, extensions):
     """Check if photo is wanted based on extension."""
@@ -25,7 +57,7 @@ def photo_wanted(photo, extensions):
 def generate_file_name(photo, file_size, destination_path, folder_format):
     """Generate full path to file."""
     filename = photo.filename
-    name, extension = filename.rsplit(".", 1) if "." in filename else [filename, ""]
+    name, extension = get_name_and_extension(photo, file_size)
     file_path = os.path.join(destination_path, filename)
     file_size_path = os.path.join(
         destination_path,
@@ -60,6 +92,16 @@ def generate_file_name(photo, file_size, destination_path, folder_format):
     if os.path.isfile(file_size_id_path):
         os.rename(file_size_id_path, file_size_id_path_norm)
     return file_size_id_path_norm
+
+
+def get_name_and_extension(photo, file_size):
+    filename = photo.filename
+    name, extension = filename.rsplit(".", 1) if "." in filename else [filename, ""]
+    if file_size == "original_alt" and file_size in photo.versions:
+        extension = original_alt_filetype_to_extension[
+            photo.versions[file_size]["type"]
+        ]
+    return name, extension
 
 
 def photo_exists(photo, file_size, local_path):

--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -98,9 +98,12 @@ def get_name_and_extension(photo, file_size):
     filename = photo.filename
     name, extension = filename.rsplit(".", 1) if "." in filename else [filename, ""]
     if file_size == "original_alt" and file_size in photo.versions:
-        extension = original_alt_filetype_to_extension[
-            photo.versions[file_size]["type"]
-        ]
+        filetype = photo.versions[file_size]["type"]
+        if filetype in original_alt_filetype_to_extension:
+            extension = original_alt_filetype_to_extension[filetype]
+        else:
+            LOGGER.debug(f"Unknown filetype {filetype} for "
+                         f"original_alt version of {filename}")
     return name, extension
 
 


### PR DESCRIPTION
I noticed that my original_alt RAW files from JPEG + RAW photos are downloaded with `.jpg` extension and not as Olympus ORF RAW files as they should. Here is the fix for that.

I was not able to figure out whether extension for `resOriginalAltRes`is returned from iCloud, so as far as I see, the best bet is to hardcode mapping from `type` field to extensions. 
The mapping I took from [here](https://github.com/steilerDev/icloud-photos-sync/blob/f26620dd3a8d5d66f283342656735d8ad60b3eb7/app/src/lib/photos-library/model/file-type.ts#L4).