### PR TITLE
Load config.yaml from mounted config volume

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,7 +19,7 @@ ENV_ICLOUD_PASSWORD_KEY = "ENV_ICLOUD_PASSWORD"
 ENV_CONFIG_FILE_PATH_KEY = "ENV_CONFIG_FILE_PATH"
 DEFAULT_LOGGER_LEVEL = "info"
 DEFAULT_LOG_FILE_NAME = "icloud.log"
-DEFAULT_CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME)
+DEFAULT_CONFIG_FILE_PATH = os.path.join('/config', DEFAULT_CONFIG_FILE_NAME)
 DEFAULT_COOKIE_DIRECTORY = "/config/session_data"
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)


### PR DESCRIPTION
The `config.yaml` is loaded from the working directory, which is created during image build, instead of loaded from mounted config volume. 

The behavior of current version does not match descriptions in the sample `docker-compose.yaml`. This commit fixes this problem.