### PR TITLE
Load logger configuration from path defined in ENV_CONFIG_FILE_PATH

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -98,7 +98,7 @@ class ColorfulConsoleFormatter(logging.Formatter):
 def get_logger():
     """Return logger."""
     logger = logging.getLogger()
-    logger_config = get_logger_config(config=read_config())
+    logger_config = get_logger_config(config=read_config(config_path=os.environ.get(ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH)))
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
         logger.setLevel(level=level_name)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,7 +19,7 @@ ENV_ICLOUD_PASSWORD_KEY = "ENV_ICLOUD_PASSWORD"
 ENV_CONFIG_FILE_PATH_KEY = "ENV_CONFIG_FILE_PATH"
 DEFAULT_LOGGER_LEVEL = "info"
 DEFAULT_LOG_FILE_NAME = "icloud.log"
-DEFAULT_CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME)
+DEFAULT_CONFIG_FILE_PATH = os.path.join('/config', DEFAULT_CONFIG_FILE_NAME)
 DEFAULT_COOKIE_DIRECTORY = "/config/session_data"
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,7 +19,7 @@ ENV_ICLOUD_PASSWORD_KEY = "ENV_ICLOUD_PASSWORD"
 ENV_CONFIG_FILE_PATH_KEY = "ENV_CONFIG_FILE_PATH"
 DEFAULT_LOGGER_LEVEL = "info"
 DEFAULT_LOG_FILE_NAME = "icloud.log"
-DEFAULT_CONFIG_FILE_PATH = os.path.join('/config', DEFAULT_CONFIG_FILE_NAME)
+DEFAULT_CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME)
 DEFAULT_COOKIE_DIRECTORY = "/config/session_data"
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)


### PR DESCRIPTION
This commit fixes a bug that forces loggers to read configurations from the config.yaml inside the docker image