### PR TITLE
Add comments to clarify 'remove_obsolete' option in configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ app:
   region: global # For China server users, set this to - china (default: global)
 drive:
   destination: "drive"
+  # Remove local files that are not present on server (i.e. files delete on server)
   remove_obsolete: false
   sync_interval: 300
   filters: # Optional - use it only if you want to download specific folders.
@@ -119,6 +120,7 @@ drive:
     - "*.md"
 photos:
   destination: "photos"
+  # Remove local photos that are not present on server (i.e. photos delete on server)
   remove_obsolete: false
   sync_interval: 500
   all_albums: false # Optional, default false. If true preserve album structure. If same photo is in multiple albums creates duplicates on filesystem

--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,7 @@ app:
   region: global
 drive:
   destination: "drive"
+  # Remove local files that are not present on server (i.e. files delete on server)
   remove_obsolete: false
   sync_interval: 300
   filters:
@@ -52,6 +53,7 @@ drive:
       - "jpeg"
 photos:
   destination: "photos"
+  # Remove local photos that are not present on server (i.e. photos delete on server)
   remove_obsolete: false
   sync_interval: 500
   all_albums: false # Optional, default false. If true preserve album structure. If same photo is in multiple albums creates duplicates on filesystem

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -34,6 +34,7 @@ app:
 
 drive:
   destination: "./drive"
+  # Remove local files that are not present on server (i.e. files delete on server)
   remove_obsolete: true
   sync_interval: -1
   ignore:
@@ -62,6 +63,7 @@ drive:
       - xmcf
 photos:
   destination: photos
+  # Remove local photos that are not present on server (i.e. photos delete on server)
   remove_obsolete: false
   sync_interval: -1
   all_albums: false # Optional, default false. If true preserve album structure. If same photo is in multpile albums creates duplicates on filesystem


### PR DESCRIPTION
Fixes #297

## Summary by Sourcery

Documentation:
- Adds comments to the configuration files and README to clarify the meaning of the 'remove_obsolete' option.