### PR TITLE
Fix for #176 (Hardlinks)

### DIFF
--- a/tests/test_sync_photos_hardlink_exceptions.py
+++ b/tests/test_sync_photos_hardlink_exceptions.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src import sync_photos
+
+
+class TestSyncPhotosHardlinkExceptions(unittest.TestCase):
+    def setUp(self):
+        self.photo = MagicMock()
+        self.photo.filename = "test.jpg"
+        self.photo.versions = {"original": {"size": "100"}}
+        self.photo.id = "photoid"
+        self.photo.created = MagicMock(strftime=lambda fmt: "2025-06")
+        self.file_size = "original"
+        self.folder_format = None
+        self.files = set()
+        self.destination_path = "/tmp/album"
+        self.all_photos_path = "/tmp/all"
+
+    @patch("os.path.samefile", side_effect=OSError("Simulated samefile error"))
+    @patch("os.path.exists", return_value=True)
+    def test_compare_directories_exception(self, mock_exists, mock_samefile):
+        # Should log a warning and continue to download_photo
+        with (
+            patch("src.sync_photos.generate_file_name", return_value="/tmp/all/test.jpg"),
+            patch("src.sync_photos.photo_exists", return_value=False),
+            patch("src.sync_photos.download_photo") as mock_download,
+        ):
+            sync_photos.process_photo(
+                self.photo,
+                self.file_size,
+                self.destination_path,
+                self.files,
+                self.folder_format,
+                self.all_photos_path,
+            )
+            mock_download.assert_called_once()
+
+    @patch("os.path.samefile", return_value=False)
+    @patch("os.path.exists", return_value=True)
+    def test_hardlink_inner_exception(self, mock_exists, mock_samefile):
+        # Simulate error in os.link
+        with (
+            patch("src.sync_photos.generate_file_name", return_value="/tmp/all/test.jpg"),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.exists", return_value=True),
+            patch("os.remove"),
+            patch("os.link", side_effect=OSError("Simulated link error")),
+            patch("src.sync_photos.photo_exists", return_value=False),
+            patch("src.sync_photos.download_photo") as mock_download,
+        ):
+            sync_photos.process_photo(
+                self.photo,
+                self.file_size,
+                self.destination_path,
+                self.files,
+                self.folder_format,
+                self.all_photos_path,
+            )
+            mock_download.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…ception handling

## Summary by Sourcery

Enable optional hardlinking from a central 'all' directory to dedupe photo downloads across albums, with robust exception handling and tests to ensure fallback to downloading on errors.

New Features:
- Enable hardlink deduplication by linking photos from a central 'all' directory when syncing albums

Bug Fixes:
- Catch and log exceptions from os.path.samefile and os.link and fallback to downloading

Enhancements:
- Extend process_photo and sync_album signatures with all_photos_path to coordinate hardlink logic
- Always sync the 'All Photos' library first to serve as the hardlink source

Tests:
- Add unit tests for exception handling in hardlinking to ensure fallback download occurs