### PR TITLE
Allow user to specify priority for Pushover notifications

### DIFF
--- a/NOTIFICATION_CONFIG.md
+++ b/NOTIFICATION_CONFIG.md
@@ -58,6 +58,7 @@ app:
   pushover:
     user_key: "your-30-char-user-key"
     api_token: "your-30-char-app-token"
+    priority: "your-notification-priority"
 ```
 
 **Setup Steps:**
@@ -185,6 +186,7 @@ app:
   pushover:
     user_key: "user-key"
     api_token: "app-token"
+    priority: 1
   smtp:
     email: "icloud@domain.com"
     to: "admin@domain.com"

--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,7 @@ app:
   pushover:
   # user_key: <your Pushover user key>
   # api_token: <your Pushover api token>
+  # priority: <your notification priority (optional)>
   smtp:
   # If you want to receive email notifications about expired/missing 2FA credentials then uncomment
   # email: "sender@test.com"

--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -907,6 +907,17 @@ def get_pushover_api_token(config: dict) -> str | None:
     """
     return get_notification_config_value(config, "pushover", "api_token")
 
+def get_pushover_notification_priority(config: dict) -> int | None:
+    """Return Pushover notification priority from config.
+
+    Args:
+        config: Configuration dictionary
+
+    Returns:
+        Pushover notification priority if configured, None otherwise
+    """
+    return get_notification_config_value(config, "pushover", "priority")
+
 
 # =============================================================================
 # Sync Summary Notification Configuration Functions

--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -916,7 +916,8 @@ def get_pushover_notification_priority(config: dict) -> int | None:
     Returns:
         Pushover notification priority if configured, None otherwise
     """
-    return get_notification_config_value(config, "pushover", "priority")
+    config_path = ["app", "pushover", "priority"]
+    return get_config_value_or_none(config=config, config_path=config_path)
 
 
 # =============================================================================

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -581,6 +581,19 @@ class TestConfigParser(unittest.TestCase):
         """None config for Pushover API token."""
         self.assertIsNone(config_parser.get_pushover_api_token(config=None))
 
+    def test_get_pushover_notification_priority(self):
+        """Test for getting Pushover notification priority."""
+        config = read_config(config_path=tests.CONFIG_PATH)
+        config["app"]["pushover"] = {"priority": 1}
+        self.assertEqual(
+            config["app"]["pushover"]["priority"],
+            config_parser.get_pushover_notification_priority(config=config),
+        )
+
+    def test_get_pushover_notification_priority_none_config(self):
+        """None config for Pushover notification priority."""
+        self.assertIsNone(config_parser.get_pushover_notification_priority(config=None))
+
     def test_get_app_max_threads_default(self):
         """Test for getting app max threads with default value."""
         config = read_config(config_path=tests.CONFIG_PATH)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -794,6 +794,7 @@ class TestNotify(unittest.TestCase):
             post_message_mock.assert_called_once_with(
                 self.config["app"]["pushover"]["api_token"],
                 self.config["app"]["pushover"]["user_key"],
+                None,
                 self.message_body,
             )
 
@@ -807,6 +808,7 @@ class TestNotify(unittest.TestCase):
             post_message_mock.assert_called_once_with(
                 self.config["app"]["pushover"]["api_token"],
                 self.config["app"]["pushover"]["user_key"],
+                None,
                 self.message_body,
             )
 
@@ -848,7 +850,7 @@ class TestNotify(unittest.TestCase):
         """Test for successful post to Pushover."""
         with patch("requests.post") as post_mock:
             post_mock.return_value.status_code = 200
-            post_message_to_pushover("pushover_api_token", "pushover_user_key", "message")
+            post_message_to_pushover("pushover_api_token", "pushover_user_key", None, "message")
 
             # Verify that post is called with the correct arguments
             post_mock.assert_called_once_with(
@@ -861,12 +863,38 @@ class TestNotify(unittest.TestCase):
         """Test for failed post to Pushover."""
         with patch("requests.post") as post_mock:
             post_mock.return_value.status_code = 400
-            post_message_to_pushover("pushover_api_token", "pushover_user_key", "message")
+            post_message_to_pushover("pushover_api_token", "pushover_user_key", None, "message")
 
             # Verify that post is called with the correct arguments
             post_mock.assert_called_once_with(
                 "https://api.pushover.net/1/messages.json",
                 data={"token": "pushover_api_token", "user": "pushover_user_key", "message": "message"},
+                timeout=10,
+            )
+
+    def test_post_message_to_pushover_with_priority(self):
+        """Test for post to Pushover with priority."""
+        with patch("requests.post") as post_mock:
+            post_mock.return_value.status_code = 200
+            post_message_to_pushover("pushover_api_token", "pushover_user_key", 1, "message")
+
+            # Verify that post is called with the correct arguments including priority
+            post_mock.assert_called_once_with(
+                "https://api.pushover.net/1/messages.json",
+                data={"token": "pushover_api_token", "user": "pushover_user_key", "message": "message", "priority": 1},
+                timeout=10,
+            )
+
+    def test_post_message_to_pushover_with_priority_zero(self):
+        """Test for post to Pushover with priority zero."""
+        with patch("requests.post") as post_mock:
+            post_mock.return_value.status_code = 200
+            post_message_to_pushover("pushover_api_token", "pushover_user_key", 0, "message")
+
+            # Verify that post is called with priority=0 (should not be excluded due to truthiness check)
+            post_mock.assert_called_once_with(
+                "https://api.pushover.net/1/messages.json",
+                data={"token": "pushover_api_token", "user": "pushover_user_key", "message": "message", "priority": 0},
                 timeout=10,
             )
 


### PR DESCRIPTION
Hi,

Thanks again for this wonderful piece of software! I'm a big fan of the notification feature you added. I primarily use Pushover for my notifications, but wanted a way to control the priority which affects how the notification is received on my devices. For example a -1 priority will show the notification on my device but won't trigger a vibration which is nice given I am syncing every 6 hours :)

I tested this PR locally - let me know if it's missing anything. Appreciate it!