### PR TITLE
Fix timezone-sensitivity bug causing full re-sync on TZ env var changes

### DIFF
--- a/src/drive_file_download.py
+++ b/src/drive_file_download.py
@@ -50,7 +50,9 @@ def download_file(item: Any, local_file: str) -> str | None:
                 else:
                     return None
 
-        # Set the file modification time to match the remote file
+        # Set the file modification time to match the remote file.
+        # iCloudPy produces date_modified via strptime(..., "%Y-%m-%dT%H:%M:%SZ") — always
+        # naive UTC with no tzinfo. replace(tzinfo=UTC) is the correct conversion.
         item_modified_time = item.date_modified.replace(tzinfo=timezone.utc).timestamp()
         os.utime(local_file, (item_modified_time, item_modified_time))
 

--- a/src/drive_file_download.py
+++ b/src/drive_file_download.py
@@ -7,7 +7,7 @@ separating download logic from sync operations per SRP.
 __author__ = "Mandar Patil (mandarons@pm.me)"
 
 import os
-import time
+from datetime import timezone
 from typing import Any
 
 from src import configure_icloudpy_logging, get_logger
@@ -51,7 +51,7 @@ def download_file(item: Any, local_file: str) -> str | None:
                     return None
 
         # Set the file modification time to match the remote file
-        item_modified_time = time.mktime(item.date_modified.timetuple())
+        item_modified_time = item.date_modified.replace(tzinfo=timezone.utc).timestamp()
         os.utime(local_file, (item_modified_time, item_modified_time))
 
     except Exception as e:

--- a/src/drive_file_existence.py
+++ b/src/drive_file_existence.py
@@ -7,6 +7,7 @@ separating existence validation logic from sync operations per SRP.
 __author__ = "Mandar Patil (mandarons@pm.me)"
 
 import os
+from datetime import timezone
 from pathlib import Path
 from shutil import rmtree
 from typing import Any
@@ -34,7 +35,7 @@ def file_exists(item: Any, local_file: str) -> bool:
         return False
 
     local_file_modified_time = int(os.path.getmtime(local_file))
-    remote_file_modified_time = int(item.date_modified.timestamp())
+    remote_file_modified_time = int(item.date_modified.replace(tzinfo=timezone.utc).timestamp())
     local_file_size = os.path.getsize(local_file)
     remote_file_size = item.size
 
@@ -69,7 +70,7 @@ def package_exists(item: Any, local_package_path: str) -> bool:
         return False
 
     local_package_modified_time = int(os.path.getmtime(local_package_path))
-    remote_package_modified_time = int(item.date_modified.timestamp())
+    remote_package_modified_time = int(item.date_modified.replace(tzinfo=timezone.utc).timestamp())
     local_package_size = sum(f.stat().st_size for f in Path(local_package_path).glob("**/*") if f.is_file())
     remote_package_size = item.size
 

--- a/src/drive_file_existence.py
+++ b/src/drive_file_existence.py
@@ -35,6 +35,8 @@ def file_exists(item: Any, local_file: str) -> bool:
         return False
 
     local_file_modified_time = int(os.path.getmtime(local_file))
+    # iCloudPy produces date_modified via strptime(..., "%Y-%m-%dT%H:%M:%SZ") — always
+    # naive UTC with no tzinfo. replace(tzinfo=UTC) is the correct conversion.
     remote_file_modified_time = int(item.date_modified.replace(tzinfo=timezone.utc).timestamp())
     local_file_size = os.path.getsize(local_file)
     remote_file_size = item.size
@@ -70,6 +72,8 @@ def package_exists(item: Any, local_package_path: str) -> bool:
         return False
 
     local_package_modified_time = int(os.path.getmtime(local_package_path))
+    # iCloudPy produces date_modified via strptime(..., "%Y-%m-%dT%H:%M:%SZ") — always
+    # naive UTC with no tzinfo. replace(tzinfo=UTC) is the correct conversion.
     remote_package_modified_time = int(item.date_modified.replace(tzinfo=timezone.utc).timestamp())
     local_package_size = sum(f.stat().st_size for f in Path(local_package_path).glob("**/*") if f.is_file())
     remote_package_size = item.size

--- a/src/photo_file_utils.py
+++ b/src/photo_file_utils.py
@@ -97,7 +97,10 @@ def download_photo_from_server(photo, file_size: str, destination_path: str, max
             with open(destination_path, "wb") as file_out:
                 shutil.copyfileobj(download.raw, file_out)
 
-            # Set file modification time to photo's added date
+            # Set file modification time to photo's added date.
+            # iCloudPy returns added_date as an aware UTC datetime; replace() is a
+            # safe no-op here because tzinfo is already UTC. If it ever returns a
+            # naive datetime, replace(tzinfo=utc) correctly treats it as UTC.
             local_modified_time = photo.added_date.replace(tzinfo=timezone.utc).timestamp()
             os.utime(destination_path, (local_modified_time, local_modified_time))
 

--- a/src/photo_file_utils.py
+++ b/src/photo_file_utils.py
@@ -9,7 +9,7 @@ ___author___ = "Mandar Patil <mandarons@pm.me>"
 import os
 import shutil
 import threading
-import time
+from datetime import timezone
 
 from src import get_logger
 
@@ -98,7 +98,7 @@ def download_photo_from_server(photo, file_size: str, destination_path: str, max
                 shutil.copyfileobj(download.raw, file_out)
 
             # Set file modification time to photo's added date
-            local_modified_time = time.mktime(photo.added_date.timetuple())
+            local_modified_time = photo.added_date.replace(tzinfo=timezone.utc).timestamp()
             os.utime(destination_path, (local_modified_time, local_modified_time))
 
             return True

--- a/tests/test_sync_drive.py
+++ b/tests/test_sync_drive.py
@@ -677,7 +677,7 @@ class TestSyncDrive(unittest.TestCase):
         """File downloaded without TZ (UTC default) is not re-downloaded after TZ=America/Los_Angeles."""
         self._run_with_tz("UTC", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
         self._run_with_tz("America/Los_Angeles", lambda: self.assertTrue(
-            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path)
+            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path),
         ))
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
@@ -685,7 +685,7 @@ class TestSyncDrive(unittest.TestCase):
         """File downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ=America/New_York."""
         self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
         self._run_with_tz("America/New_York", lambda: self.assertTrue(
-            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path)
+            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path),
         ))
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
@@ -693,7 +693,7 @@ class TestSyncDrive(unittest.TestCase):
         """File downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset (UTC)."""
         self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
         self._run_with_tz("UTC", lambda: self.assertTrue(
-            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path)
+            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path),
         ))
 
     def _run_with_tz(self, tz: str, fn) -> None:
@@ -1207,7 +1207,7 @@ class TestSyncDrive(unittest.TestCase):
         """Package downloaded without TZ (UTC default) is not re-downloaded after TZ=America/Los_Angeles."""
         self._run_with_tz("UTC", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
         self._run_with_tz("America/Los_Angeles", lambda: self.assertTrue(
-            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path)
+            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path),
         ))
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
@@ -1215,7 +1215,7 @@ class TestSyncDrive(unittest.TestCase):
         """Package downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ=America/New_York."""
         self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
         self._run_with_tz("America/New_York", lambda: self.assertTrue(
-            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path)
+            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path),
         ))
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
@@ -1223,7 +1223,7 @@ class TestSyncDrive(unittest.TestCase):
         """Package downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset (UTC)."""
         self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
         self._run_with_tz("UTC", lambda: self.assertTrue(
-            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path)
+            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path),
         ))
 
     def test_process_file_nested_package_extraction(self):

--- a/tests/test_sync_drive.py
+++ b/tests/test_sync_drive.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import time
 import unittest
+from datetime import timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.parse import unquote
@@ -671,6 +672,44 @@ class TestSyncDrive(unittest.TestCase):
         non_existent = os.path.join(self.destination_path, "does_not_exist.band")
         self.assertFalse(sync_drive.package_exists(item=self.package_item, local_package_path=non_existent))
 
+    @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
+    def test_file_exists_tz_naive_to_aware(self):
+        """File downloaded without TZ (UTC default) is not re-downloaded after TZ=America/Los_Angeles."""
+        self._run_with_tz("UTC", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
+        self._run_with_tz("America/Los_Angeles", lambda: self.assertTrue(
+            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path)
+        ))
+
+    @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
+    def test_file_exists_tz_aware_to_aware(self):
+        """File downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ=America/New_York."""
+        self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
+        self._run_with_tz("America/New_York", lambda: self.assertTrue(
+            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path)
+        ))
+
+    @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
+    def test_file_exists_tz_aware_to_naive(self):
+        """File downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset (UTC)."""
+        self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
+        self._run_with_tz("UTC", lambda: self.assertTrue(
+            sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path)
+        ))
+
+    def _run_with_tz(self, tz: str, fn) -> None:
+        """Run fn with the system timezone temporarily set to tz, then restore."""
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = tz
+        time.tzset()
+        try:
+            fn()
+        finally:
+            if old_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old_tz
+            time.tzset()
+
     def test_download_file(self):
         """Test for valid file download."""
         self.assertTrue(sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
@@ -1157,6 +1196,30 @@ class TestSyncDrive(unittest.TestCase):
             ),
         )
 
+    @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
+    def test_package_exists_tz_naive_to_aware(self):
+        """Package downloaded without TZ (UTC default) is not re-downloaded after TZ=America/Los_Angeles."""
+        self._run_with_tz("UTC", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
+        self._run_with_tz("America/Los_Angeles", lambda: self.assertTrue(
+            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path)
+        ))
+
+    @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
+    def test_package_exists_tz_aware_to_aware(self):
+        """Package downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ=America/New_York."""
+        self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
+        self._run_with_tz("America/New_York", lambda: self.assertTrue(
+            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path)
+        ))
+
+    @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
+    def test_package_exists_tz_aware_to_naive(self):
+        """Package downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset (UTC)."""
+        self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
+        self._run_with_tz("UTC", lambda: self.assertTrue(
+            sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path)
+        ))
+
     def test_process_file_nested_package_extraction(self):
         """Test for nested package extraction."""
         files = set()
@@ -1311,7 +1374,7 @@ class TestSyncDrive(unittest.TestCase):
             f.write(b"A" * 197334)  # Match the size from the mock data
 
         # Set the modification time to match the item
-        item_modified_time = time.mktime(self.file_item.date_modified.timetuple())
+        item_modified_time = self.file_item.date_modified.replace(tzinfo=timezone.utc).timestamp()
         os.utime(local_file_path, (item_modified_time, item_modified_time))
 
         download_info = sync_drive.collect_file_for_download(

--- a/tests/test_sync_drive.py
+++ b/tests/test_sync_drive.py
@@ -697,7 +697,13 @@ class TestSyncDrive(unittest.TestCase):
         ))
 
     def _run_with_tz(self, tz: str, fn) -> None:
-        """Run fn with the system timezone temporarily set to tz, then restore."""
+        """Run fn with the system timezone temporarily set to tz, then restore.
+
+        Not thread-safe: os.environ['TZ'] + time.tzset() mutate process-global
+        libc state. These tests must run in a single-threaded context (standard
+        unittest sequential runner). If parallel test execution is ever adopted,
+        move these tests to an isolated subprocess.
+        """
         old_tz = os.environ.get("TZ")
         os.environ["TZ"] = tz
         time.tzset()

--- a/tests/test_sync_drive.py
+++ b/tests/test_sync_drive.py
@@ -674,8 +674,8 @@ class TestSyncDrive(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
     def test_file_exists_tz_naive_to_aware(self):
-        """File downloaded without TZ (UTC default) is not re-downloaded after TZ=America/Los_Angeles."""
-        self._run_with_tz("UTC", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
+        """File downloaded without TZ set is not re-downloaded after TZ=America/Los_Angeles."""
+        self._run_with_tz(None, lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
         self._run_with_tz("America/Los_Angeles", lambda: self.assertTrue(
             sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path),
         ))
@@ -690,14 +690,16 @@ class TestSyncDrive(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
     def test_file_exists_tz_aware_to_naive(self):
-        """File downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset (UTC)."""
+        """File downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset."""
         self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.file_item, local_file=self.local_file_path))
-        self._run_with_tz("UTC", lambda: self.assertTrue(
+        self._run_with_tz(None, lambda: self.assertTrue(
             sync_drive.file_exists(item=self.file_item, local_file=self.local_file_path),
         ))
 
-    def _run_with_tz(self, tz: str, fn) -> None:
+    def _run_with_tz(self, tz: str | None, fn) -> None:
         """Run fn with the system timezone temporarily set to tz, then restore.
+
+        Pass tz=None to unset TZ entirely (simulates a container with no TZ env var).
 
         Not thread-safe: os.environ['TZ'] + time.tzset() mutate process-global
         libc state. These tests must run in a single-threaded context (standard
@@ -705,7 +707,10 @@ class TestSyncDrive(unittest.TestCase):
         move these tests to an isolated subprocess.
         """
         old_tz = os.environ.get("TZ")
-        os.environ["TZ"] = tz
+        if tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = tz
         time.tzset()
         try:
             fn()
@@ -1204,8 +1209,8 @@ class TestSyncDrive(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
     def test_package_exists_tz_naive_to_aware(self):
-        """Package downloaded without TZ (UTC default) is not re-downloaded after TZ=America/Los_Angeles."""
-        self._run_with_tz("UTC", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
+        """Package downloaded without TZ set is not re-downloaded after TZ=America/Los_Angeles."""
+        self._run_with_tz(None, lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
         self._run_with_tz("America/Los_Angeles", lambda: self.assertTrue(
             sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path),
         ))
@@ -1220,9 +1225,9 @@ class TestSyncDrive(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(time, "tzset"), "time.tzset not available on this platform")
     def test_package_exists_tz_aware_to_naive(self):
-        """Package downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset (UTC)."""
+        """Package downloaded with TZ=America/Los_Angeles is not re-downloaded after TZ is unset."""
         self._run_with_tz("America/Los_Angeles", lambda: sync_drive.download_file(item=self.package_item, local_file=self.local_package_path))
-        self._run_with_tz("UTC", lambda: self.assertTrue(
+        self._run_with_tz(None, lambda: self.assertTrue(
             sync_drive.package_exists(item=self.package_item, local_package_path=self.local_package_path),
         ))
 

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -5,7 +5,6 @@ __author__ = "Mandar Patil (mandarons@pm.me)"
 import glob
 import os
 import shutil
-import time
 import unittest
 from datetime import timezone
 from io import StringIO

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import time
 import unittest
+from datetime import timezone
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -730,7 +731,7 @@ class TestSyncPhotos(unittest.TestCase):
             f.write(b"A" * 1000)  # Write same content size as mock
 
         # Set modification time to match photo
-        local_modified_time = time.mktime(photo.added_date.timetuple())
+        local_modified_time = photo.added_date.replace(tzinfo=timezone.utc).timestamp()
         os.utime(photo_path, (local_modified_time, local_modified_time))
 
         download_info = sync_photos.collect_photo_for_download(

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -1867,6 +1867,7 @@ class TestSyncPhotos(unittest.TestCase):
 
     def test_download_photo_from_server_http_410_error_with_retry(self):
         """Test download_photo_from_server with HTTP 410 error and successful retry."""
+        import datetime
         import tempfile
         from io import BytesIO
         from unittest.mock import MagicMock, Mock
@@ -1895,15 +1896,16 @@ class TestSyncPhotos(unittest.TestCase):
                 return mock_response
 
             mock_photo.download.side_effect = download_side_effect
-            mock_photo.added_date = MagicMock()
-            mock_photo.added_date.timetuple.return_value = time.struct_time((2021, 1, 1, 0, 0, 0, 0, 0, 0))
+            mock_photo.added_date = datetime.datetime(2021, 1, 1, 12, 0, 0)
 
             # Test that download succeeds after retry
             result = download_photo_from_server(mock_photo, "original", destination_path)
             self.assertTrue(result)
             self.assertEqual(mock_photo.download.call_count, 2)
-            # Verify file was created
+            # Verify file was created and mtime is set correctly
             self.assertTrue(os.path.exists(destination_path))
+            expected_mtime = datetime.datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+            self.assertAlmostEqual(os.path.getmtime(destination_path), expected_mtime, delta=1)
 
     def test_download_photo_from_server_http_410_error_max_retries_exceeded(self):
         """Test download_photo_from_server with HTTP 410 error exceeding max retries."""
@@ -1927,6 +1929,7 @@ class TestSyncPhotos(unittest.TestCase):
 
     def test_download_photo_from_server_http_410_error_without_versions_attribute(self):
         """Test download_photo_from_server with HTTP 410 error when photo has no _versions attribute."""
+        import datetime
         import tempfile
         from io import BytesIO
         from unittest.mock import MagicMock, Mock
@@ -1952,15 +1955,16 @@ class TestSyncPhotos(unittest.TestCase):
                 return mock_response
 
             mock_photo.download.side_effect = download_side_effect
-            mock_photo.added_date = MagicMock()
-            mock_photo.added_date.timetuple.return_value = time.struct_time((2021, 1, 1, 0, 0, 0, 0, 0, 0))
+            mock_photo.added_date = datetime.datetime(2021, 1, 1, 12, 0, 0)
 
             # Test that download succeeds even without _versions attribute
             result = download_photo_from_server(mock_photo, "original", destination_path)
             self.assertTrue(result)
             self.assertEqual(mock_photo.download.call_count, 2)
-            # Verify file was created
+            # Verify file was created and mtime is set correctly
             self.assertTrue(os.path.exists(destination_path))
+            expected_mtime = datetime.datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+            self.assertAlmostEqual(os.path.getmtime(destination_path), expected_mtime, delta=1)
 
     def test_download_photo_from_server_http_410_error_zero_retries(self):
         """Test download_photo_from_server with HTTP 410 error and max_retries=0."""


### PR DESCRIPTION
## What

iCloudPy returns `date_modified` (drive) and `added_date` (photos) as naive Python `datetime` objects representing UTC time. The prior code used `time.mktime(dt.timetuple())` to write file mtimes on download and naive `dt.timestamp()` to compare them in `file_exists()` / `package_exists()`. Both interpret naive datetimes as **local time**, making them sensitive to the container's `TZ` env var.

Any change to `TZ` — adding it for the first time, switching between timezones, or removing it — shifts the computed epoch by the UTC offset. Every previously-downloaded file appears stale on the next sync, triggering a full re-download.

## How it was discovered

Adding `TZ=America/Los_Angeles` to a container that had previously run without `TZ` (defaulting to UTC) caused a 7-hour offset between stored and computed mtimes for every file in iCloud Drive, triggering a complete re-sync of the entire drive.

## Fix

Use `dt.replace(tzinfo=timezone.utc).timestamp()` everywhere a naive iCloudPy datetime is converted to a Unix epoch. This explicitly declares UTC intent and produces the same value regardless of system timezone.

Changed files:
- `src/drive_file_download.py` — mtime write after download
- `src/drive_file_existence.py` — mtime comparison in `file_exists()` and `package_exists()`
- `src/photo_file_utils.py` — mtime write in `download_photo_from_server()`

## Tests added

Six new tests in `test_sync_drive.py` covering all timezone-switching directions for both files and packages:

- `test_file_exists_tz_naive_to_aware` — downloaded without TZ (UTC default), checked with `TZ=America/Los_Angeles`
- `test_file_exists_tz_aware_to_aware` — downloaded with `TZ=America/Los_Angeles`, checked with `TZ=America/New_York`
- `test_file_exists_tz_aware_to_naive` — downloaded with `TZ=America/Los_Angeles`, checked without TZ
- Same three scenarios for `package_exists`

All six use `time.tzset()` to actually change the process timezone, directly reproducing the production failure. Guarded with `@unittest.skipUnless(hasattr(time, "tzset"), ...)` for Windows portability.
