### PR TITLE
test: green the suite on non-container dev hosts (macOS, sandboxes, etc.)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -20,13 +20,11 @@ ENV_ICLOUD_PASSWORD_KEY = "ENV_ICLOUD_PASSWORD"
 ENV_CONFIG_FILE_PATH_KEY = "ENV_CONFIG_FILE_PATH"
 DEFAULT_LOGGER_LEVEL = "info"
 DEFAULT_LOG_FILE_NAME = "icloud.log"
-DEFAULT_CONFIG_FILE_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME,
-)
-# Operator-overridable via ICLOUD_DOCKER_CONFIG_DIR. Default ``/config`` is
-# the in-container mount point users bind their config volume to. Setting
-# this env var lets the test suite run on macOS / non-container hosts
-# where ``/config`` isn't writable.
+DEFAULT_CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME)
+# Operator-overridable via ICLOUD_DOCKER_CONFIG_DIR. Default ``/config`` is the
+# in-container mount point users bind their config volume to. The override
+# lets the test suite run on hosts where ``/config`` isn't writable (macOS,
+# sandboxes).
 _CONFIG_DIR = os.environ.get("ICLOUD_DOCKER_CONFIG_DIR", "/config")
 DEFAULT_COOKIE_DIRECTORY = os.path.join(_CONFIG_DIR, "session_data")
 
@@ -41,9 +39,7 @@ def read_config(config_path=DEFAULT_CONFIG_FILE_PATH):
     with open(file=config_path, encoding="utf-8") as config_file:
         config = YAML().load(config_file)
     config["app"]["credentials"]["username"] = (
-        config["app"]["credentials"]["username"].strip()
-        if config["app"]["credentials"]["username"] is not None
-        else ""
+        config["app"]["credentials"]["username"].strip() if config["app"]["credentials"]["username"] is not None else ""
     )
     return config
 
@@ -55,14 +51,10 @@ def get_logger_config(config):
         return None
     config_app_logger = config["app"]["logger"]
     logger_config["level"] = (
-        config_app_logger["level"].strip().lower()
-        if "level" in config_app_logger
-        else DEFAULT_LOGGER_LEVEL
+        config_app_logger["level"].strip().lower() if "level" in config_app_logger else DEFAULT_LOGGER_LEVEL
     )
     logger_config["filename"] = (
-        config_app_logger["filename"].strip().lower()
-        if "filename" in config_app_logger
-        else DEFAULT_LOG_FILE_NAME
+        config_app_logger["filename"].strip().lower() if "filename" in config_app_logger else DEFAULT_LOG_FILE_NAME
     )
     return logger_config
 
@@ -111,13 +103,7 @@ class ColorfulConsoleFormatter(logging.Formatter):
 
 def configure_icloudpy_logging():
     """Configure icloudpy logging to match app logging level."""
-    logger_config = get_logger_config(
-        config=read_config(
-            config_path=os.environ.get(
-                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH,
-            ),
-        ),
-    )
+    logger_config = get_logger_config(config=read_config(config_path=os.environ.get(ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH)))
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
 
@@ -139,13 +125,7 @@ def configure_icloudpy_logging():
 def get_logger():
     """Return logger."""
     logger = logging.getLogger()
-    logger_config = get_logger_config(
-        config=read_config(
-            config_path=os.environ.get(
-                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH,
-            ),
-        ),
-    )
+    logger_config = get_logger_config(config=read_config(config_path=os.environ.get(ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH)))
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
         logger.setLevel(level=level_name)
@@ -167,9 +147,7 @@ def get_logger():
             )
             logger.addHandler(file_handler)
 
-        if not log_handler_exists(
-            logger=logger, handler_type=logging.StreamHandler, stream=sys.stdout,
-        ):
+        if not log_handler_exists(logger=logger, handler_type=logging.StreamHandler, stream=sys.stdout):
             console_handler = logging.StreamHandler(sys.stdout)
             console_handler.setFormatter(
                 ColorfulConsoleFormatter(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -21,7 +21,7 @@ ENV_CONFIG_FILE_PATH_KEY = "ENV_CONFIG_FILE_PATH"
 DEFAULT_LOGGER_LEVEL = "info"
 DEFAULT_LOG_FILE_NAME = "icloud.log"
 DEFAULT_CONFIG_FILE_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME
+    os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME,
 )
 # Operator-overridable via ICLOUD_DOCKER_CONFIG_DIR. Default ``/config`` is
 # the in-container mount point users bind their config volume to. Setting
@@ -114,9 +114,9 @@ def configure_icloudpy_logging():
     logger_config = get_logger_config(
         config=read_config(
             config_path=os.environ.get(
-                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH
-            )
-        )
+                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH,
+            ),
+        ),
     )
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
@@ -142,9 +142,9 @@ def get_logger():
     logger_config = get_logger_config(
         config=read_config(
             config_path=os.environ.get(
-                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH
-            )
-        )
+                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH,
+            ),
+        ),
     )
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
@@ -168,7 +168,7 @@ def get_logger():
             logger.addHandler(file_handler)
 
         if not log_handler_exists(
-            logger=logger, handler_type=logging.StreamHandler, stream=sys.stdout
+            logger=logger, handler_type=logging.StreamHandler, stream=sys.stdout,
         ):
             console_handler = logging.StreamHandler(sys.stdout)
             console_handler.setFormatter(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -20,8 +20,15 @@ ENV_ICLOUD_PASSWORD_KEY = "ENV_ICLOUD_PASSWORD"
 ENV_CONFIG_FILE_PATH_KEY = "ENV_CONFIG_FILE_PATH"
 DEFAULT_LOGGER_LEVEL = "info"
 DEFAULT_LOG_FILE_NAME = "icloud.log"
-DEFAULT_CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME)
-DEFAULT_COOKIE_DIRECTORY = "/config/session_data"
+DEFAULT_CONFIG_FILE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME
+)
+# Operator-overridable via ICLOUD_DOCKER_CONFIG_DIR. Default ``/config`` is
+# the in-container mount point users bind their config volume to. Setting
+# this env var lets the test suite run on macOS / non-container hosts
+# where ``/config`` isn't writable.
+_CONFIG_DIR = os.environ.get("ICLOUD_DOCKER_CONFIG_DIR", "/config")
+DEFAULT_COOKIE_DIRECTORY = os.path.join(_CONFIG_DIR, "session_data")
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -34,7 +41,9 @@ def read_config(config_path=DEFAULT_CONFIG_FILE_PATH):
     with open(file=config_path, encoding="utf-8") as config_file:
         config = YAML().load(config_file)
     config["app"]["credentials"]["username"] = (
-        config["app"]["credentials"]["username"].strip() if config["app"]["credentials"]["username"] is not None else ""
+        config["app"]["credentials"]["username"].strip()
+        if config["app"]["credentials"]["username"] is not None
+        else ""
     )
     return config
 
@@ -46,10 +55,14 @@ def get_logger_config(config):
         return None
     config_app_logger = config["app"]["logger"]
     logger_config["level"] = (
-        config_app_logger["level"].strip().lower() if "level" in config_app_logger else DEFAULT_LOGGER_LEVEL
+        config_app_logger["level"].strip().lower()
+        if "level" in config_app_logger
+        else DEFAULT_LOGGER_LEVEL
     )
     logger_config["filename"] = (
-        config_app_logger["filename"].strip().lower() if "filename" in config_app_logger else DEFAULT_LOG_FILE_NAME
+        config_app_logger["filename"].strip().lower()
+        if "filename" in config_app_logger
+        else DEFAULT_LOG_FILE_NAME
     )
     return logger_config
 
@@ -98,7 +111,13 @@ class ColorfulConsoleFormatter(logging.Formatter):
 
 def configure_icloudpy_logging():
     """Configure icloudpy logging to match app logging level."""
-    logger_config = get_logger_config(config=read_config(config_path=os.environ.get(ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH)))
+    logger_config = get_logger_config(
+        config=read_config(
+            config_path=os.environ.get(
+                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH
+            )
+        )
+    )
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
 
@@ -120,7 +139,13 @@ def configure_icloudpy_logging():
 def get_logger():
     """Return logger."""
     logger = logging.getLogger()
-    logger_config = get_logger_config(config=read_config(config_path=os.environ.get(ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH)))
+    logger_config = get_logger_config(
+        config=read_config(
+            config_path=os.environ.get(
+                ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH
+            )
+        )
+    )
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
         logger.setLevel(level=level_name)
@@ -142,7 +167,9 @@ def get_logger():
             )
             logger.addHandler(file_handler)
 
-        if not log_handler_exists(logger=logger, handler_type=logging.StreamHandler, stream=sys.stdout):
+        if not log_handler_exists(
+            logger=logger, handler_type=logging.StreamHandler, stream=sys.stdout
+        ):
             console_handler = logging.StreamHandler(sys.stdout)
             console_handler.setFormatter(
                 ColorfulConsoleFormatter(

--- a/src/sync.py
+++ b/src/sync.py
@@ -32,7 +32,7 @@ LOGGER = get_logger()
 def get_api_instance(
     username: str,
     password: str,
-    cookie_directory: str = DEFAULT_COOKIE_DIRECTORY,
+    cookie_directory: str | None = None,
     server_region: str = "global",
 ) -> ICloudPyService:
     """
@@ -41,12 +41,24 @@ def get_api_instance(
     Args:
         username: iCloud username/Apple ID
         password: iCloud password
-        cookie_directory: Directory to store authentication cookies
+        cookie_directory: Directory to store authentication cookies.
+            When ``None`` (the default), resolved late from
+            ``src.DEFAULT_COOKIE_DIRECTORY`` so test fixtures that
+            redirect the constant at runtime take effect (the previous
+            ``str = DEFAULT_COOKIE_DIRECTORY`` capture made the default
+            unmockable post-import).
         server_region: Server region ("china" or "global")
 
     Returns:
         Configured ICloudPyService instance
     """
+    if cookie_directory is None:
+        # Late-bound import so conftest fixtures that monkey-patch
+        # ``src.DEFAULT_COOKIE_DIRECTORY`` for tests on hosts without
+        # ``/config`` (macOS, sandboxes) actually take effect.
+        import src as _src
+
+        cookie_directory = _src.DEFAULT_COOKIE_DIRECTORY
     return (
         ICloudPyService(
             apple_id=username,
@@ -107,9 +119,13 @@ def _extract_sync_intervals(config, log_messages: bool = False):
     photos_sync_interval = 0
 
     if config and "drive" in config:
-        drive_sync_interval = config_parser.get_drive_sync_interval(config=config, log_messages=log_messages)
+        drive_sync_interval = config_parser.get_drive_sync_interval(
+            config=config, log_messages=log_messages
+        )
     if config and "photos" in config:
-        photos_sync_interval = config_parser.get_photos_sync_interval(config=config, log_messages=log_messages)
+        photos_sync_interval = config_parser.get_photos_sync_interval(
+            config=config, log_messages=log_messages
+        )
 
     return drive_sync_interval, photos_sync_interval
 
@@ -151,7 +167,9 @@ def _authenticate_and_get_api(config, username: str):
     """
     server_region = config_parser.get_region(config=config)
     password = _retrieve_password(username)
-    return get_api_instance(username=username, password=password, server_region=server_region)
+    return get_api_instance(
+        username=username, password=password, server_region=server_region
+    )
 
 
 def _perform_drive_sync(config, api, sync_state: SyncState, drive_sync_interval: int):
@@ -276,9 +294,13 @@ def _perform_photos_sync(config, api, sync_state: SyncState, photos_sync_interva
         stats.photos_downloaded = len(new_files)
 
         # Estimate hardlinked photos (approximate)
-        use_hardlinks = config_parser.get_photos_use_hardlinks(config=config, log_messages=False)
+        use_hardlinks = config_parser.get_photos_use_hardlinks(
+            config=config, log_messages=False
+        )
         if use_hardlinks:
-            stats.photos_hardlinked = max(0, len(files_after) - len(files_before) - stats.photos_downloaded)
+            stats.photos_hardlinked = max(
+                0, len(files_after) - len(files_before) - stats.photos_downloaded
+            )
 
         # Count skipped photos
         stats.photos_skipped = len(files_before & files_after)
@@ -343,12 +365,20 @@ def _send_usage_statistics(config, summary: SyncSummary) -> None:
     # Create anonymized usage data
     usage_data = {
         "sync_duration": (
-            (summary.sync_end_time - summary.sync_start_time).total_seconds() if summary.sync_end_time else 0
+            (summary.sync_end_time - summary.sync_start_time).total_seconds()
+            if summary.sync_end_time
+            else 0
         ),
-        "has_drive_activity": bool(summary.drive_stats and summary.drive_stats.has_activity()),
-        "has_photos_activity": bool(summary.photo_stats and summary.photo_stats.has_activity()),
+        "has_drive_activity": bool(
+            summary.drive_stats and summary.drive_stats.has_activity()
+        ),
+        "has_photos_activity": bool(
+            summary.photo_stats and summary.photo_stats.has_activity()
+        ),
         "has_errors": summary.has_errors(),
-        "timestamp": summary.sync_end_time.isoformat() if summary.sync_end_time else None,
+        "timestamp": (
+            summary.sync_end_time.isoformat() if summary.sync_end_time else None
+        ),
     }
 
     # Add aggregated statistics (no personal data)
@@ -414,7 +444,9 @@ def _handle_password_error(config, username: str, sync_state: SyncState):
     Returns:
         bool: True if should continue (retry), False if should exit
     """
-    LOGGER.error("Password is not stored in keyring. Please save the password in keyring.")
+    LOGGER.error(
+        "Password is not stored in keyring. Please save the password in keyring."
+    )
     sleep_for = config_parser.get_retry_login_interval(config=config)
 
     if sleep_for < 0:
@@ -440,7 +472,9 @@ def _log_retry_time(sleep_for: int):
     Args:
         sleep_for: Sleep duration in seconds
     """
-    next_sync = (datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)).strftime("%c")
+    next_sync = (
+        datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)
+    ).strftime("%c")
     LOGGER.info(f"Retrying login at {next_sync} ...")
 
 
@@ -469,15 +503,24 @@ def _calculate_next_sync_schedule(config, sync_state: SyncState):
         sleep_for = sync_state.drive_time_remaining
         sync_state.enable_sync_drive = True
         sync_state.enable_sync_photos = False
-    elif has_drive and has_photos and sync_state.drive_time_remaining <= sync_state.photos_time_remaining:
+    elif (
+        has_drive
+        and has_photos
+        and sync_state.drive_time_remaining <= sync_state.photos_time_remaining
+    ):
         # Special case: if both timers are equal and large (> 10 seconds), wait for the full interval
         # This fixes the bug where equal large intervals cause immediate re-sync
-        if sync_state.drive_time_remaining == sync_state.photos_time_remaining and sync_state.drive_time_remaining > 10:
+        if (
+            sync_state.drive_time_remaining == sync_state.photos_time_remaining
+            and sync_state.drive_time_remaining > 10
+        ):
             sleep_for = sync_state.drive_time_remaining
             sync_state.enable_sync_drive = True
             sync_state.enable_sync_photos = True
         else:
-            sleep_for = sync_state.photos_time_remaining - sync_state.drive_time_remaining
+            sleep_for = (
+                sync_state.photos_time_remaining - sync_state.drive_time_remaining
+            )
             sync_state.photos_time_remaining -= sync_state.drive_time_remaining
             sync_state.enable_sync_drive = True
             sync_state.enable_sync_photos = False
@@ -497,7 +540,9 @@ def _log_next_sync_time(sleep_for: int):
     Args:
         sleep_for: Sleep duration in seconds
     """
-    next_sync = (datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)).strftime("%c")
+    next_sync = (
+        datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)
+    ).strftime("%c")
     LOGGER.info(f"Resyncing at {next_sync} ...")
 
 
@@ -557,7 +602,9 @@ def sync():
             _log_sync_intervals_at_startup(config)
             startup_logged = True
 
-        drive_sync_interval, photos_sync_interval = _extract_sync_intervals(config, log_messages=False)
+        drive_sync_interval, photos_sync_interval = _extract_sync_intervals(
+            config, log_messages=False
+        )
         username = config_parser.get_username(config=config) if config else None
 
         if username:
@@ -569,8 +616,12 @@ def sync():
                     summary = SyncSummary()
 
                     # Perform syncs and collect statistics
-                    drive_stats = _perform_drive_sync(config, api, sync_state, drive_sync_interval)
-                    photos_stats = _perform_photos_sync(config, api, sync_state, photos_sync_interval)
+                    drive_stats = _perform_drive_sync(
+                        config, api, sync_state, drive_sync_interval
+                    )
+                    photos_stats = _perform_photos_sync(
+                        config, api, sync_state, photos_sync_interval
+                    )
 
                     # Populate summary with statistics
                     summary.drive_stats = drive_stats
@@ -592,7 +643,9 @@ def sync():
                     should_send_notification = False
                     if has_drive_config and has_photos_config:
                         # Both services configured - send notification only when both have synced
-                        should_send_notification = drive_stats is not None and photos_stats is not None
+                        should_send_notification = (
+                            drive_stats is not None and photos_stats is not None
+                        )
                     elif has_drive_config and not has_photos_config:
                         # Only drive configured - send when drive synced
                         should_send_notification = drive_stats is not None
@@ -604,10 +657,14 @@ def sync():
                         try:
                             notify.send_sync_summary(config=config, summary=summary)
                         except Exception as e:
-                            LOGGER.debug(f"Failed to send sync summary notification: {e!s}")
+                            LOGGER.debug(
+                                f"Failed to send sync summary notification: {e!s}"
+                            )
 
                     if not _check_services_configured(config):
-                        LOGGER.warning("Nothing to sync. Please add drive: and/or photos: section in config.yaml file.")
+                        LOGGER.warning(
+                            "Nothing to sync. Please add drive: and/or photos: section in config.yaml file."
+                        )
                 else:
                     if not _handle_2fa_required(config, username, sync_state):
                         break
@@ -622,7 +679,9 @@ def sync():
         _log_next_sync_time(sleep_for)
 
         if _should_exit_oneshot_mode(config):
-            LOGGER.info("All configured sync intervals are negative, exiting oneshot mode...")
+            LOGGER.info(
+                "All configured sync intervals are negative, exiting oneshot mode..."
+            )
             break
 
         sleep(sleep_for)

--- a/src/sync.py
+++ b/src/sync.py
@@ -9,7 +9,6 @@ from icloudpy import ICloudPyService, exceptions, utils
 
 from src import (
     DEFAULT_CONFIG_FILE_PATH,
-    DEFAULT_COOKIE_DIRECTORY,
     ENV_CONFIG_FILE_PATH_KEY,
     ENV_ICLOUD_PASSWORD_KEY,
     config_parser,
@@ -120,11 +119,11 @@ def _extract_sync_intervals(config, log_messages: bool = False):
 
     if config and "drive" in config:
         drive_sync_interval = config_parser.get_drive_sync_interval(
-            config=config, log_messages=log_messages
+            config=config, log_messages=log_messages,
         )
     if config and "photos" in config:
         photos_sync_interval = config_parser.get_photos_sync_interval(
-            config=config, log_messages=log_messages
+            config=config, log_messages=log_messages,
         )
 
     return drive_sync_interval, photos_sync_interval
@@ -168,7 +167,7 @@ def _authenticate_and_get_api(config, username: str):
     server_region = config_parser.get_region(config=config)
     password = _retrieve_password(username)
     return get_api_instance(
-        username=username, password=password, server_region=server_region
+        username=username, password=password, server_region=server_region,
     )
 
 
@@ -295,11 +294,11 @@ def _perform_photos_sync(config, api, sync_state: SyncState, photos_sync_interva
 
         # Estimate hardlinked photos (approximate)
         use_hardlinks = config_parser.get_photos_use_hardlinks(
-            config=config, log_messages=False
+            config=config, log_messages=False,
         )
         if use_hardlinks:
             stats.photos_hardlinked = max(
-                0, len(files_after) - len(files_before) - stats.photos_downloaded
+                0, len(files_after) - len(files_before) - stats.photos_downloaded,
             )
 
         # Count skipped photos
@@ -370,10 +369,10 @@ def _send_usage_statistics(config, summary: SyncSummary) -> None:
             else 0
         ),
         "has_drive_activity": bool(
-            summary.drive_stats and summary.drive_stats.has_activity()
+            summary.drive_stats and summary.drive_stats.has_activity(),
         ),
         "has_photos_activity": bool(
-            summary.photo_stats and summary.photo_stats.has_activity()
+            summary.photo_stats and summary.photo_stats.has_activity(),
         ),
         "has_errors": summary.has_errors(),
         "timestamp": (
@@ -445,7 +444,7 @@ def _handle_password_error(config, username: str, sync_state: SyncState):
         bool: True if should continue (retry), False if should exit
     """
     LOGGER.error(
-        "Password is not stored in keyring. Please save the password in keyring."
+        "Password is not stored in keyring. Please save the password in keyring.",
     )
     sleep_for = config_parser.get_retry_login_interval(config=config)
 
@@ -603,7 +602,7 @@ def sync():
             startup_logged = True
 
         drive_sync_interval, photos_sync_interval = _extract_sync_intervals(
-            config, log_messages=False
+            config, log_messages=False,
         )
         username = config_parser.get_username(config=config) if config else None
 
@@ -617,10 +616,10 @@ def sync():
 
                     # Perform syncs and collect statistics
                     drive_stats = _perform_drive_sync(
-                        config, api, sync_state, drive_sync_interval
+                        config, api, sync_state, drive_sync_interval,
                     )
                     photos_stats = _perform_photos_sync(
-                        config, api, sync_state, photos_sync_interval
+                        config, api, sync_state, photos_sync_interval,
                     )
 
                     # Populate summary with statistics
@@ -658,12 +657,12 @@ def sync():
                             notify.send_sync_summary(config=config, summary=summary)
                         except Exception as e:
                             LOGGER.debug(
-                                f"Failed to send sync summary notification: {e!s}"
+                                f"Failed to send sync summary notification: {e!s}",
                             )
 
                     if not _check_services_configured(config):
                         LOGGER.warning(
-                            "Nothing to sync. Please add drive: and/or photos: section in config.yaml file."
+                            "Nothing to sync. Please add drive: and/or photos: section in config.yaml file.",
                         )
                 else:
                     if not _handle_2fa_required(config, username, sync_state):
@@ -680,7 +679,7 @@ def sync():
 
         if _should_exit_oneshot_mode(config):
             LOGGER.info(
-                "All configured sync intervals are negative, exiting oneshot mode..."
+                "All configured sync intervals are negative, exiting oneshot mode...",
             )
             break
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -43,21 +43,23 @@ def get_api_instance(
         cookie_directory: Directory to store authentication cookies.
             When ``None`` (the default), resolved late from
             ``src.DEFAULT_COOKIE_DIRECTORY`` so test fixtures that
-            redirect the constant at runtime take effect (the previous
-            ``str = DEFAULT_COOKIE_DIRECTORY`` capture made the default
-            unmockable post-import).
+            redirect the constant at runtime take effect — the previous
+            ``= DEFAULT_COOKIE_DIRECTORY`` default-arg capture made the
+            constant unmockable post-import.
         server_region: Server region ("china" or "global")
 
     Returns:
         Configured ICloudPyService instance
     """
     if cookie_directory is None:
-        # Late-bound import so conftest fixtures that monkey-patch
-        # ``src.DEFAULT_COOKIE_DIRECTORY`` for tests on hosts without
-        # ``/config`` (macOS, sandboxes) actually take effect.
-        import src as _src
+        # Read through the src module so monkey-patches of
+        # ``src.DEFAULT_COOKIE_DIRECTORY`` (e.g. by tests/conftest.py)
+        # are honoured. ``src`` is this function's parent package and
+        # already imported; using ``sys.modules`` avoids a per-call
+        # ``import src`` and makes the data flow explicit.
+        import sys
 
-        cookie_directory = _src.DEFAULT_COOKIE_DIRECTORY
+        cookie_directory = sys.modules["src"].DEFAULT_COOKIE_DIRECTORY
     return (
         ICloudPyService(
             apple_id=username,
@@ -118,13 +120,9 @@ def _extract_sync_intervals(config, log_messages: bool = False):
     photos_sync_interval = 0
 
     if config and "drive" in config:
-        drive_sync_interval = config_parser.get_drive_sync_interval(
-            config=config, log_messages=log_messages,
-        )
+        drive_sync_interval = config_parser.get_drive_sync_interval(config=config, log_messages=log_messages)
     if config and "photos" in config:
-        photos_sync_interval = config_parser.get_photos_sync_interval(
-            config=config, log_messages=log_messages,
-        )
+        photos_sync_interval = config_parser.get_photos_sync_interval(config=config, log_messages=log_messages)
 
     return drive_sync_interval, photos_sync_interval
 
@@ -166,9 +164,7 @@ def _authenticate_and_get_api(config, username: str):
     """
     server_region = config_parser.get_region(config=config)
     password = _retrieve_password(username)
-    return get_api_instance(
-        username=username, password=password, server_region=server_region,
-    )
+    return get_api_instance(username=username, password=password, server_region=server_region)
 
 
 def _perform_drive_sync(config, api, sync_state: SyncState, drive_sync_interval: int):
@@ -293,13 +289,9 @@ def _perform_photos_sync(config, api, sync_state: SyncState, photos_sync_interva
         stats.photos_downloaded = len(new_files)
 
         # Estimate hardlinked photos (approximate)
-        use_hardlinks = config_parser.get_photos_use_hardlinks(
-            config=config, log_messages=False,
-        )
+        use_hardlinks = config_parser.get_photos_use_hardlinks(config=config, log_messages=False)
         if use_hardlinks:
-            stats.photos_hardlinked = max(
-                0, len(files_after) - len(files_before) - stats.photos_downloaded,
-            )
+            stats.photos_hardlinked = max(0, len(files_after) - len(files_before) - stats.photos_downloaded)
 
         # Count skipped photos
         stats.photos_skipped = len(files_before & files_after)
@@ -364,20 +356,12 @@ def _send_usage_statistics(config, summary: SyncSummary) -> None:
     # Create anonymized usage data
     usage_data = {
         "sync_duration": (
-            (summary.sync_end_time - summary.sync_start_time).total_seconds()
-            if summary.sync_end_time
-            else 0
+            (summary.sync_end_time - summary.sync_start_time).total_seconds() if summary.sync_end_time else 0
         ),
-        "has_drive_activity": bool(
-            summary.drive_stats and summary.drive_stats.has_activity(),
-        ),
-        "has_photos_activity": bool(
-            summary.photo_stats and summary.photo_stats.has_activity(),
-        ),
+        "has_drive_activity": bool(summary.drive_stats and summary.drive_stats.has_activity()),
+        "has_photos_activity": bool(summary.photo_stats and summary.photo_stats.has_activity()),
         "has_errors": summary.has_errors(),
-        "timestamp": (
-            summary.sync_end_time.isoformat() if summary.sync_end_time else None
-        ),
+        "timestamp": (summary.sync_end_time.isoformat() if summary.sync_end_time else None),
     }
 
     # Add aggregated statistics (no personal data)
@@ -443,9 +427,7 @@ def _handle_password_error(config, username: str, sync_state: SyncState):
     Returns:
         bool: True if should continue (retry), False if should exit
     """
-    LOGGER.error(
-        "Password is not stored in keyring. Please save the password in keyring.",
-    )
+    LOGGER.error("Password is not stored in keyring. Please save the password in keyring.")
     sleep_for = config_parser.get_retry_login_interval(config=config)
 
     if sleep_for < 0:
@@ -471,9 +453,7 @@ def _log_retry_time(sleep_for: int):
     Args:
         sleep_for: Sleep duration in seconds
     """
-    next_sync = (
-        datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)
-    ).strftime("%c")
+    next_sync = (datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)).strftime("%c")
     LOGGER.info(f"Retrying login at {next_sync} ...")
 
 
@@ -502,24 +482,15 @@ def _calculate_next_sync_schedule(config, sync_state: SyncState):
         sleep_for = sync_state.drive_time_remaining
         sync_state.enable_sync_drive = True
         sync_state.enable_sync_photos = False
-    elif (
-        has_drive
-        and has_photos
-        and sync_state.drive_time_remaining <= sync_state.photos_time_remaining
-    ):
+    elif has_drive and has_photos and sync_state.drive_time_remaining <= sync_state.photos_time_remaining:
         # Special case: if both timers are equal and large (> 10 seconds), wait for the full interval
         # This fixes the bug where equal large intervals cause immediate re-sync
-        if (
-            sync_state.drive_time_remaining == sync_state.photos_time_remaining
-            and sync_state.drive_time_remaining > 10
-        ):
+        if sync_state.drive_time_remaining == sync_state.photos_time_remaining and sync_state.drive_time_remaining > 10:
             sleep_for = sync_state.drive_time_remaining
             sync_state.enable_sync_drive = True
             sync_state.enable_sync_photos = True
         else:
-            sleep_for = (
-                sync_state.photos_time_remaining - sync_state.drive_time_remaining
-            )
+            sleep_for = sync_state.photos_time_remaining - sync_state.drive_time_remaining
             sync_state.photos_time_remaining -= sync_state.drive_time_remaining
             sync_state.enable_sync_drive = True
             sync_state.enable_sync_photos = False
@@ -539,9 +510,7 @@ def _log_next_sync_time(sleep_for: int):
     Args:
         sleep_for: Sleep duration in seconds
     """
-    next_sync = (
-        datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)
-    ).strftime("%c")
+    next_sync = (datetime.datetime.now() + datetime.timedelta(seconds=sleep_for)).strftime("%c")
     LOGGER.info(f"Resyncing at {next_sync} ...")
 
 
@@ -601,9 +570,7 @@ def sync():
             _log_sync_intervals_at_startup(config)
             startup_logged = True
 
-        drive_sync_interval, photos_sync_interval = _extract_sync_intervals(
-            config, log_messages=False,
-        )
+        drive_sync_interval, photos_sync_interval = _extract_sync_intervals(config, log_messages=False)
         username = config_parser.get_username(config=config) if config else None
 
         if username:
@@ -615,12 +582,8 @@ def sync():
                     summary = SyncSummary()
 
                     # Perform syncs and collect statistics
-                    drive_stats = _perform_drive_sync(
-                        config, api, sync_state, drive_sync_interval,
-                    )
-                    photos_stats = _perform_photos_sync(
-                        config, api, sync_state, photos_sync_interval,
-                    )
+                    drive_stats = _perform_drive_sync(config, api, sync_state, drive_sync_interval)
+                    photos_stats = _perform_photos_sync(config, api, sync_state, photos_sync_interval)
 
                     # Populate summary with statistics
                     summary.drive_stats = drive_stats
@@ -642,9 +605,7 @@ def sync():
                     should_send_notification = False
                     if has_drive_config and has_photos_config:
                         # Both services configured - send notification only when both have synced
-                        should_send_notification = (
-                            drive_stats is not None and photos_stats is not None
-                        )
+                        should_send_notification = drive_stats is not None and photos_stats is not None
                     elif has_drive_config and not has_photos_config:
                         # Only drive configured - send when drive synced
                         should_send_notification = drive_stats is not None
@@ -656,14 +617,10 @@ def sync():
                         try:
                             notify.send_sync_summary(config=config, summary=summary)
                         except Exception as e:
-                            LOGGER.debug(
-                                f"Failed to send sync summary notification: {e!s}",
-                            )
+                            LOGGER.debug(f"Failed to send sync summary notification: {e!s}")
 
                     if not _check_services_configured(config):
-                        LOGGER.warning(
-                            "Nothing to sync. Please add drive: and/or photos: section in config.yaml file.",
-                        )
+                        LOGGER.warning("Nothing to sync. Please add drive: and/or photos: section in config.yaml file.")
                 else:
                     if not _handle_2fa_required(config, username, sync_state):
                         break
@@ -678,9 +635,7 @@ def sync():
         _log_next_sync_time(sleep_for)
 
         if _should_exit_oneshot_mode(config):
-            LOGGER.info(
-                "All configured sync intervals are negative, exiting oneshot mode...",
-            )
+            LOGGER.info("All configured sync intervals are negative, exiting oneshot mode...")
             break
 
         sleep(sleep_for)

--- a/src/usage.py
+++ b/src/usage.py
@@ -14,7 +14,12 @@ from src.config_parser import get_usage_tracking_enabled, prepare_root_destinati
 
 LOGGER = get_logger()
 
-CACHE_FILE_NAME = "/config/.data"
+# Same ICLOUD_DOCKER_CONFIG_DIR override as ``DEFAULT_COOKIE_DIRECTORY``.
+# Defaults to ``/config/.data`` to match upstream mandarons; tests on
+# non-container hosts (macOS, etc) override via the env var.
+CACHE_FILE_NAME = os.path.join(
+    os.environ.get("ICLOUD_DOCKER_CONFIG_DIR", "/config"), ".data"
+)
 NEW_INSTALLATION_ENDPOINT = os.environ.get("NEW_INSTALLATION_ENDPOINT", None)
 NEW_HEARTBEAT_ENDPOINT = os.environ.get("NEW_HEARTBEAT_ENDPOINT", None)
 APP_NAME = "icloud-docker"
@@ -92,7 +97,9 @@ def load_cache(file_path: str) -> dict:
                 data = loaded_data
                 LOGGER.debug(f"Loaded and validated usage cache from: {file_path}")
             else:
-                LOGGER.warning(f"Cache data validation failed for {file_path}, starting fresh")
+                LOGGER.warning(
+                    f"Cache data validation failed for {file_path}, starting fresh"
+                )
                 save_cache(file_path=file_path, data={})
         except (json.JSONDecodeError, OSError) as e:
             LOGGER.error(f"Failed to load usage cache from {file_path}: {e}")
@@ -178,7 +185,8 @@ def post_with_retry(
 
             # Rate limit (429) or server error (5xx) - retry
             LOGGER.warning(
-                f"Request failed with status {response.status_code}, " f"attempt {attempt + 1}/{max_retries}",
+                f"Request failed with status {response.status_code}, "
+                f"attempt {attempt + 1}/{max_retries}",
             )
 
         except (requests.ConnectionError, requests.Timeout) as e:
@@ -252,7 +260,11 @@ def already_installed(cached_data: dict) -> bool:
     Returns:
         True if installation is up-to-date, False otherwise
     """
-    return "id" in cached_data and "app_version" in cached_data and cached_data["app_version"] == APP_VERSION
+    return (
+        "id" in cached_data
+        and "app_version" in cached_data
+        and cached_data["app_version"] == APP_VERSION
+    )
 
 
 def install(cached_data: dict) -> dict | None:

--- a/src/usage.py
+++ b/src/usage.py
@@ -14,12 +14,12 @@ from src.config_parser import get_usage_tracking_enabled, prepare_root_destinati
 
 LOGGER = get_logger()
 
-# Same ICLOUD_DOCKER_CONFIG_DIR override as ``DEFAULT_COOKIE_DIRECTORY``.
-# Defaults to ``/config/.data`` to match upstream mandarons; tests on
-# non-container hosts (macOS, etc) override via the env var.
-CACHE_FILE_NAME = os.path.join(
-    os.environ.get("ICLOUD_DOCKER_CONFIG_DIR", "/config"), ".data",
-)
+# Same ICLOUD_DOCKER_CONFIG_DIR override as ``DEFAULT_COOKIE_DIRECTORY``
+# in ``src/__init__.py`` — lets the test suite on non-container hosts
+# (macOS, sandboxes) redirect the usage cache to a writable tempdir
+# instead of the read-only ``/config`` mount point. Defaults to
+# ``/config/.data`` so production container deployments are unchanged.
+CACHE_FILE_NAME = os.path.join(os.environ.get("ICLOUD_DOCKER_CONFIG_DIR", "/config"), ".data")
 NEW_INSTALLATION_ENDPOINT = os.environ.get("NEW_INSTALLATION_ENDPOINT", None)
 NEW_HEARTBEAT_ENDPOINT = os.environ.get("NEW_HEARTBEAT_ENDPOINT", None)
 APP_NAME = "icloud-docker"
@@ -97,9 +97,7 @@ def load_cache(file_path: str) -> dict:
                 data = loaded_data
                 LOGGER.debug(f"Loaded and validated usage cache from: {file_path}")
             else:
-                LOGGER.warning(
-                    f"Cache data validation failed for {file_path}, starting fresh",
-                )
+                LOGGER.warning(f"Cache data validation failed for {file_path}, starting fresh")
                 save_cache(file_path=file_path, data={})
         except (json.JSONDecodeError, OSError) as e:
             LOGGER.error(f"Failed to load usage cache from {file_path}: {e}")
@@ -185,8 +183,7 @@ def post_with_retry(
 
             # Rate limit (429) or server error (5xx) - retry
             LOGGER.warning(
-                f"Request failed with status {response.status_code}, "
-                f"attempt {attempt + 1}/{max_retries}",
+                f"Request failed with status {response.status_code}, " f"attempt {attempt + 1}/{max_retries}",
             )
 
         except (requests.ConnectionError, requests.Timeout) as e:
@@ -260,11 +257,7 @@ def already_installed(cached_data: dict) -> bool:
     Returns:
         True if installation is up-to-date, False otherwise
     """
-    return (
-        "id" in cached_data
-        and "app_version" in cached_data
-        and cached_data["app_version"] == APP_VERSION
-    )
+    return "id" in cached_data and "app_version" in cached_data and cached_data["app_version"] == APP_VERSION
 
 
 def install(cached_data: dict) -> dict | None:

--- a/src/usage.py
+++ b/src/usage.py
@@ -18,7 +18,7 @@ LOGGER = get_logger()
 # Defaults to ``/config/.data`` to match upstream mandarons; tests on
 # non-container hosts (macOS, etc) override via the env var.
 CACHE_FILE_NAME = os.path.join(
-    os.environ.get("ICLOUD_DOCKER_CONFIG_DIR", "/config"), ".data"
+    os.environ.get("ICLOUD_DOCKER_CONFIG_DIR", "/config"), ".data",
 )
 NEW_INSTALLATION_ENDPOINT = os.environ.get("NEW_INSTALLATION_ENDPOINT", None)
 NEW_HEARTBEAT_ENDPOINT = os.environ.get("NEW_HEARTBEAT_ENDPOINT", None)
@@ -98,7 +98,7 @@ def load_cache(file_path: str) -> dict:
                 LOGGER.debug(f"Loaded and validated usage cache from: {file_path}")
             else:
                 LOGGER.warning(
-                    f"Cache data validation failed for {file_path}, starting fresh"
+                    f"Cache data validation failed for {file_path}, starting fresh",
                 )
                 save_cache(file_path=file_path, data={})
         except (json.JSONDecodeError, OSError) as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Pytest fixtures shared across the test tree.
+
+Session-wide redirect of ``ICLOUD_DOCKER_CONFIG_DIR`` to a writable
+tempdir. The container's ``/config`` mount doesn't exist on dev hosts
+(macOS especially — read-only root). Without this redirect, the suite
+hits FileNotFoundError on ``/config/.data`` (usage cache) and
+``/config/session_data`` (icloudpy cookie dir), and a swath of tests
+fail despite the production code being correct.
+"""
+
+__author__ = "Mandar Patil (mandarons@pm.me)"
+
+import os
+import tempfile
+
+import pytest
+
+_CONFIG_DIR_KEY = "ICLOUD_DOCKER_CONFIG_DIR"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _redirect_config_dir():
+    """Session-wide ``ICLOUD_DOCKER_CONFIG_DIR`` → tempdir.
+
+    The redirect MUST be set before any ``from src import ...`` happens
+    at module-import time (because ``DEFAULT_COOKIE_DIRECTORY`` is
+    captured at import). Pytest collects conftest first, so this fires
+    early — but we also patch the cached constants here in case ``src``
+    was already imported by an earlier conftest layer.
+    """
+    if _CONFIG_DIR_KEY in os.environ:
+        # Honor explicit caller override (e.g. CI integration tests).
+        yield
+        return
+
+    tmpdir = tempfile.mkdtemp(prefix="icloud_test_config_")
+    os.environ[_CONFIG_DIR_KEY] = tmpdir
+
+    import src
+    import src.usage
+
+    src.DEFAULT_COOKIE_DIRECTORY = os.path.join(tmpdir, "session_data")
+    src.usage.CACHE_FILE_NAME = os.path.join(tmpdir, ".data")
+    os.makedirs(src.DEFAULT_COOKIE_DIRECTORY, exist_ok=True)
+    try:
+        yield
+    finally:
+        import shutil
+
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        os.environ.pop(_CONFIG_DIR_KEY, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,16 +35,25 @@ def _redirect_config_dir():
     ``ICLOUD_DOCKER_CONFIG_DIR`` at import time MUST add a matching
     reassignment here.
     """
-    if _CONFIG_DIR_KEY in os.environ:
-        # Honor explicit caller override (e.g. CI integration tests
-        # that mount their own writable ``/config``). The override path
-        # is expected to be already-resolved upstream of pytest.
-        yield
-        return
+    # Resolve the target config dir: external override if the caller
+    # set it (e.g. CI integration tests), otherwise a fresh tempdir.
+    # Note the cleanup contract differs: we never rmtree an externally
+    # supplied dir, only the tempdir we created ourselves.
+    external = _CONFIG_DIR_KEY in os.environ
+    tmpdir = (
+        os.environ[_CONFIG_DIR_KEY]
+        if external
+        else tempfile.mkdtemp(prefix="icloud_test_config_")
+    )
+    if not external:
+        os.environ[_CONFIG_DIR_KEY] = tmpdir
 
-    tmpdir = tempfile.mkdtemp(prefix="icloud_test_config_")
-    os.environ[_CONFIG_DIR_KEY] = tmpdir
-
+    # The constants were captured at import time; re-sync them to the
+    # resolved dir whether it came from env override or the tempdir.
+    # Without this re-sync on the override path, the same
+    # FileNotFoundError chain this fixture exists to prevent would
+    # resurface (callers would still read /config-resolved paths from
+    # the captured constants).
     import src
     import src.usage
 
@@ -58,7 +67,10 @@ def _redirect_config_dir():
     try:
         yield
     finally:
-        import shutil
+        # Only clean up if WE owned the tempdir — leave externally-
+        # supplied dirs (CI mounts, user-managed paths) intact.
+        if not external:
+            import shutil
 
-        shutil.rmtree(tmpdir, ignore_errors=True)
-        os.environ.pop(_CONFIG_DIR_KEY, None)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            os.environ.pop(_CONFIG_DIR_KEY, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,14 +22,23 @@ _CONFIG_DIR_KEY = "ICLOUD_DOCKER_CONFIG_DIR"
 def _redirect_config_dir():
     """Session-wide ``ICLOUD_DOCKER_CONFIG_DIR`` → tempdir.
 
-    The redirect MUST be set before any ``from src import ...`` happens
-    at module-import time (because ``DEFAULT_COOKIE_DIRECTORY`` is
-    captured at import). Pytest collects conftest first, so this fires
-    early — but we also patch the cached constants here in case ``src``
-    was already imported by an earlier conftest layer.
+    Implementation note: the ``os.environ`` setting alone is NOT what
+    makes the redirect work. ``DEFAULT_COOKIE_DIRECTORY`` and
+    ``CACHE_FILE_NAME`` are captured at module-import time, and by the
+    time this autouse fixture runs (first test execution) the test
+    modules have already done ``from src import ...`` and the constants
+    have already resolved to ``/config/...``. The reassignment of
+    ``src.DEFAULT_COOKIE_DIRECTORY`` / ``src.usage.CACHE_FILE_NAME``
+    below is what actually redirects callers. The env-var set is kept
+    only so child processes (if any) inherit the override. Future
+    contributors who add a new module that captures
+    ``ICLOUD_DOCKER_CONFIG_DIR`` at import time MUST add a matching
+    reassignment here.
     """
     if _CONFIG_DIR_KEY in os.environ:
-        # Honor explicit caller override (e.g. CI integration tests).
+        # Honor explicit caller override (e.g. CI integration tests
+        # that mount their own writable ``/config``). The override path
+        # is expected to be already-resolved upstream of pytest.
         yield
         return
 
@@ -41,7 +50,11 @@ def _redirect_config_dir():
 
     src.DEFAULT_COOKIE_DIRECTORY = os.path.join(tmpdir, "session_data")
     src.usage.CACHE_FILE_NAME = os.path.join(tmpdir, ".data")
-    os.makedirs(src.DEFAULT_COOKIE_DIRECTORY, exist_ok=True)
+    # NOTE: we deliberately do NOT pre-create ``session_data/`` here.
+    # ``tests/test_sync.py::test_sync`` asserts that ``sync.sync()``
+    # itself creates the directory on first run; pre-creating would
+    # make that assertion trivially pass regardless of whether the
+    # production code path actually ran.
     try:
         yield
     finally:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -38,18 +38,14 @@ class TestSync(unittest.TestCase):
         self.root_dir = tests.TEMP_DIR
         self.config["app"]["root"] = self.root_dir
         os.makedirs(tests.TEMP_DIR, exist_ok=True)
-        self.service = data.ICloudPyServiceMock(
-            data.AUTHENTICATED_USER, data.VALID_PASSWORD,
-        )
+        self.service = data.ICloudPyServiceMock(data.AUTHENTICATED_USER, data.VALID_PASSWORD)
 
     def tearDown(self) -> None:
         """Remove temp directories."""
         self.remove_temp()
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -67,16 +63,14 @@ class TestSync(unittest.TestCase):
         if ENV_ICLOUD_PASSWORD_KEY in os.environ:
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
         self.assertIsNone(sync.sync())
-        # Resolves to the conftest's tempdir (or /config/session_data
-        # in a real container deployment).
+        # Resolves to the conftest's tempdir on non-container hosts;
+        # ``/config/session_data`` in a real container deployment.
         from src import DEFAULT_COOKIE_DIRECTORY
 
         self.assertTrue(os.path.isdir(DEFAULT_COOKIE_DIRECTORY))
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -99,14 +93,10 @@ class TestSync(unittest.TestCase):
         self.assertIsNone(sync.sync())
         dir_length = len(os.listdir(self.root_dir))
         self.assertTrue(dir_length == 1)
-        self.assertTrue(
-            os.path.isdir(os.path.join(self.root_dir, config["photos"]["destination"])),
-        )
+        self.assertTrue(os.path.isdir(os.path.join(self.root_dir, config["photos"]["destination"])))
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -128,16 +118,12 @@ class TestSync(unittest.TestCase):
         self.remove_temp()
         mock_read_config.return_value = config
         self.assertIsNone(sync.sync())
-        self.assertTrue(
-            os.path.isdir(os.path.join(self.root_dir, config["drive"]["destination"])),
-        )
+        self.assertTrue(os.path.isdir(os.path.join(self.root_dir, config["drive"]["destination"])))
         dir_length = len(os.listdir(self.root_dir))
         self.assertTrue(dir_length == 1)
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -164,9 +150,7 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -198,9 +182,7 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -231,8 +213,7 @@ class TestSync(unittest.TestCase):
                     [
                         e
                         for e in captured[1]
-                        if "Password is not stored in keyring. Please save the password in keyring."
-                        in e
+                        if "Password is not stored in keyring. Please save the password in keyring." in e
                     ],
                 )
                 > 0,
@@ -264,22 +245,11 @@ class TestSync(unittest.TestCase):
             with patch.dict(os.environ, {ENV_ICLOUD_PASSWORD_KEY: data.VALID_PASSWORD}):
                 with self.assertRaises(Exception):
                     sync.sync()
-                self.assertTrue(
-                    len(
-                        [
-                            e
-                            for e in captured[1]
-                            if "Error: 2FA is required. Please log in." in e
-                        ],
-                    )
-                    > 0,
-                )
+                self.assertTrue(len([e for e in captured[1] if "Error: 2FA is required. Please log in." in e]) > 0)
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -308,9 +278,7 @@ class TestSync(unittest.TestCase):
     @patch(target="sys.stdout", new_callable=StringIO)
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -419,9 +387,7 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.os.path.getsize", side_effect=RuntimeError("size failure"))
     @patch("src.sync.sync_drive")
-    def test_perform_drive_sync_handles_getsize_failure(
-        self, mock_sync_drive, _mock_getsize,
-    ):
+    def test_perform_drive_sync_handles_getsize_failure(self, mock_sync_drive, _mock_getsize):
         """Gracefully handle size calculation failures when counting new files."""
 
         sync_state = sync.SyncState()
@@ -541,9 +507,7 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.os.path.getsize")
     @patch("src.sync.sync_photos.sync_photos")
-    def test_perform_photos_sync_handles_hardlink_bytes_failure(
-        self, mock_sync_photos, mock_getsize,
-    ):
+    def test_perform_photos_sync_handles_hardlink_bytes_failure(self, mock_sync_photos, mock_getsize):
         """Handle errors when estimating bytes saved by hardlinks."""
 
         class TrackingSet(set):
@@ -642,15 +606,11 @@ class TestSync(unittest.TestCase):
         self.assertFalse(stats.has_errors())
         self.assertEqual(len(stats.errors), 0)
 
-    @patch(
-        "src.sync.notify.send_sync_summary", side_effect=RuntimeError("notify failure"),
-    )
+
+    @patch("src.sync.notify.send_sync_summary", side_effect=RuntimeError("notify failure"))
     @patch("src.sync._perform_photos_sync")
     @patch("src.sync._perform_drive_sync", return_value=DriveStats(files_downloaded=1))
-    @patch(
-        "src.sync._authenticate_and_get_api",
-        return_value=SimpleNamespace(requires_2sa=False),
-    )
+    @patch("src.sync._authenticate_and_get_api", return_value=SimpleNamespace(requires_2sa=False))
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
     def test_sync_summary_notification_failure_logged(
@@ -677,10 +637,7 @@ class TestSync(unittest.TestCase):
 
         mock_notify.assert_called()
         self.assertTrue(
-            any(
-                "Failed to send sync summary notification" in message
-                for message in captured_logs.output
-            ),
+            any("Failed to send sync summary notification" in message for message in captured_logs.output),
         )
 
     @patch("src.sync.read_config")
@@ -695,9 +652,7 @@ class TestSync(unittest.TestCase):
         if ENV_ICLOUD_PASSWORD_KEY in os.environ:
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
 
-        actual = sync.get_api_instance(
-            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD,
-        )
+        actual = sync.get_api_instance(username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD)
         self.assertNotIn(".com.cn", actual.home_endpoint)
         self.assertNotIn(".com.cn", actual.setup_endpoint)
 
@@ -713,17 +668,13 @@ class TestSync(unittest.TestCase):
         if ENV_ICLOUD_PASSWORD_KEY in os.environ:
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
 
-        actual = sync.get_api_instance(
-            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD,
-        )
+        actual = sync.get_api_instance(username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD)
         self.assertNotIn(".com.cn", actual.home_endpoint)
         self.assertNotIn(".com.cn", actual.setup_endpoint)
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -751,25 +702,14 @@ class TestSync(unittest.TestCase):
             sync.sync()
         self.assertTrue(len(captured.records) > 1)
         self.assertTrue(len([e for e in captured[1] if "2FA is required" in e]) > 0)
-        self.assertTrue(
-            len(
-                [
-                    e
-                    for e in captured[1]
-                    if "retry_login_interval is < 0, exiting ..." in e
-                ],
-            )
-            > 0,
-        )
+        self.assertTrue(len([e for e in captured[1] if "retry_login_interval is < 0, exiting ..." in e]) > 0)
 
     @patch("src.sync.sleep")
     @patch(
         target="keyring.get_password",
         side_effect=exceptions.ICloudPyNoStoredPasswordAvailableException,
     )
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -796,29 +736,15 @@ class TestSync(unittest.TestCase):
             ]
             sync.sync()
         self.assertTrue(len(captured.records) > 1)
-        self.assertTrue(
-            len([e for e in captured[1] if "Password is not stored in keyring." in e])
-            > 0,
-        )
-        self.assertTrue(
-            len(
-                [
-                    e
-                    for e in captured[1]
-                    if "retry_login_interval is < 0, exiting ..." in e
-                ],
-            )
-            > 0,
-        )
+        self.assertTrue(len([e for e in captured[1] if "Password is not stored in keyring." in e]) > 0)
+        self.assertTrue(len([e for e in captured[1] if "retry_login_interval is < 0, exiting ..." in e]) > 0)
 
     @patch("src.sync.sync_drive")
     @patch("src.sync.sync_photos")
     @patch("src.sync.sleep")
     @patch("src.usage.alive")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -850,14 +776,7 @@ class TestSync(unittest.TestCase):
         # Verify the container exits with oneshot message
         self.assertTrue(len(captured.records) > 1)
         self.assertTrue(
-            len(
-                [
-                    e
-                    for e in captured[1]
-                    if "All configured sync intervals are negative, exiting oneshot mode..."
-                    in e
-                ],
-            )
+            len([e for e in captured[1] if "All configured sync intervals are negative, exiting oneshot mode..." in e])
             > 0,
         )
         # Verify sleep is never called (container exits immediately after sync)
@@ -868,9 +787,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sleep")
     @patch("src.usage.alive")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -901,14 +818,7 @@ class TestSync(unittest.TestCase):
         # Verify the container exits with oneshot message
         self.assertTrue(len(captured.records) > 1)
         self.assertTrue(
-            len(
-                [
-                    e
-                    for e in captured[1]
-                    if "All configured sync intervals are negative, exiting oneshot mode..."
-                    in e
-                ],
-            )
+            len([e for e in captured[1] if "All configured sync intervals are negative, exiting oneshot mode..." in e])
             > 0,
         )
         # Verify sleep is never called
@@ -918,9 +828,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sync_photos")
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
-    )
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -954,10 +862,7 @@ class TestSync(unittest.TestCase):
 
         # Verify it does NOT exit with oneshot message
         oneshot_messages = [
-            e
-            for e in captured[1]
-            if "All configured sync intervals are negative, exiting oneshot mode..."
-            in e
+            e for e in captured[1] if "All configured sync intervals are negative, exiting oneshot mode..." in e
         ]
         self.assertEqual(len(oneshot_messages), 0)
         # Verify sleep was called (indicating the loop continued)
@@ -966,10 +871,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.notify.send_sync_summary")
     @patch("src.sync._perform_photos_sync", return_value=None)
     @patch("src.sync._perform_drive_sync", return_value=DriveStats(files_downloaded=1))
-    @patch(
-        "src.sync._authenticate_and_get_api",
-        return_value=SimpleNamespace(requires_2sa=False),
-    )
+    @patch("src.sync._authenticate_and_get_api", return_value=SimpleNamespace(requires_2sa=False))
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
     def test_sync_notification_not_sent_when_both_services_not_synced(
@@ -1037,20 +939,12 @@ class TestSync(unittest.TestCase):
         sync_state.photos_time_remaining = 86400
 
         # Calculate next sync schedule
-        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
-            config, sync_state,
-        )
+        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
 
         # This should NOT be 0 - that's the bug causing immediate re-sync
         # When both timers are equal and both services just ran, we should wait
-        self.assertGreater(
-            sleep_for, 0, "Sleep time should not be 0 when both services just completed",
-        )
-        self.assertEqual(
-            sleep_for,
-            86400,
-            "Should wait for the full interval when both services have equal timers",
-        )
+        self.assertGreater(sleep_for, 0, "Sleep time should not be 0 when both services just completed")
+        self.assertEqual(sleep_for, 86400, "Should wait for the full interval when both services have equal timers")
 
         # When timers are equal and > 10 seconds, both services should be enabled for next sync
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
@@ -1067,18 +961,12 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 1800  # 30 min remaining
         sync_state.photos_time_remaining = 3600  # 1 hour remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
-            config, sync_state,
-        )
+        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep until drive sync time")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(
-            sync_state.enable_sync_photos, "Photos sync should be disabled",
-        )
-        self.assertEqual(
-            sync_state.photos_time_remaining, 1800, "Photos timer should be reduced",
-        )
+        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled")
+        self.assertEqual(sync_state.photos_time_remaining, 1800, "Photos timer should be reduced")
 
     def test_calculate_next_sync_schedule_photos_first(self):
         """Test that photos syncs first when its timer is smaller."""
@@ -1091,16 +979,12 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 3600  # 1 hour remaining
         sync_state.photos_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
-            config, sync_state,
-        )
+        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep until photos sync time")
         self.assertFalse(sync_state.enable_sync_drive, "Drive sync should be disabled")
         self.assertTrue(sync_state.enable_sync_photos, "Photos sync should be enabled")
-        self.assertEqual(
-            sync_state.drive_time_remaining, 1800, "Drive timer should be reduced",
-        )
+        self.assertEqual(sync_state.drive_time_remaining, 1800, "Drive timer should be reduced")
 
     def test_calculate_next_sync_schedule_drive_only(self):
         """Test scheduling when only drive is configured."""
@@ -1111,15 +995,11 @@ class TestSync(unittest.TestCase):
         sync_state = sync.SyncState()
         sync_state.drive_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
-            config, sync_state,
-        )
+        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep for drive remaining time")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(
-            sync_state.enable_sync_photos, "Photos sync should be disabled",
-        )
+        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled")
 
     def test_calculate_next_sync_schedule_photos_only(self):
         """Test scheduling when only photos is configured."""
@@ -1130,9 +1010,7 @@ class TestSync(unittest.TestCase):
         sync_state = sync.SyncState()
         sync_state.photos_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
-            config, sync_state,
-        )
+        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep for photos remaining time")
         self.assertFalse(sync_state.enable_sync_drive, "Drive sync should be disabled")
@@ -1150,19 +1028,12 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 0
         sync_state.photos_time_remaining = 0
 
-        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
-            config, sync_state,
-        )
+        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
 
         # Should have 0 sleep (immediate sync) but only drive should be enabled
-        self.assertEqual(
-            sleep_for, 0, "Should have immediate sync when both timers are 0",
-        )
+        self.assertEqual(sleep_for, 0, "Should have immediate sync when both timers are 0")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(
-            sync_state.enable_sync_photos,
-            "Photos sync should be disabled for first sync",
-        )
+        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled for first sync")
 
     def test_calculate_next_sync_schedule_equal_small_timers(self):
         """Test scheduling when both timers are equal but small (≤ 10 seconds)."""
@@ -1176,13 +1047,9 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 5
         sync_state.photos_time_remaining = 5
 
-        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
-            config, sync_state,
-        )
+        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
 
         # Should use original logic for small timers: sleep_for = 0, only drive enabled
         self.assertEqual(sleep_for, 0, "Should have 0 sleep for small equal timers")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(
-            sync_state.enable_sync_photos, "Photos sync should be disabled",
-        )
+        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -39,7 +39,7 @@ class TestSync(unittest.TestCase):
         self.config["app"]["root"] = self.root_dir
         os.makedirs(tests.TEMP_DIR, exist_ok=True)
         self.service = data.ICloudPyServiceMock(
-            data.AUTHENTICATED_USER, data.VALID_PASSWORD
+            data.AUTHENTICATED_USER, data.VALID_PASSWORD,
         )
 
     def tearDown(self) -> None:
@@ -48,7 +48,7 @@ class TestSync(unittest.TestCase):
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -75,7 +75,7 @@ class TestSync(unittest.TestCase):
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -100,12 +100,12 @@ class TestSync(unittest.TestCase):
         dir_length = len(os.listdir(self.root_dir))
         self.assertTrue(dir_length == 1)
         self.assertTrue(
-            os.path.isdir(os.path.join(self.root_dir, config["photos"]["destination"]))
+            os.path.isdir(os.path.join(self.root_dir, config["photos"]["destination"])),
         )
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -129,14 +129,14 @@ class TestSync(unittest.TestCase):
         mock_read_config.return_value = config
         self.assertIsNone(sync.sync())
         self.assertTrue(
-            os.path.isdir(os.path.join(self.root_dir, config["drive"]["destination"]))
+            os.path.isdir(os.path.join(self.root_dir, config["drive"]["destination"])),
         )
         dir_length = len(os.listdir(self.root_dir))
         self.assertTrue(dir_length == 1)
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -165,7 +165,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -199,7 +199,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -270,15 +270,15 @@ class TestSync(unittest.TestCase):
                             e
                             for e in captured[1]
                             if "Error: 2FA is required. Please log in." in e
-                        ]
+                        ],
                     )
-                    > 0
+                    > 0,
                 )
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -309,7 +309,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -420,7 +420,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.os.path.getsize", side_effect=RuntimeError("size failure"))
     @patch("src.sync.sync_drive")
     def test_perform_drive_sync_handles_getsize_failure(
-        self, mock_sync_drive, _mock_getsize
+        self, mock_sync_drive, _mock_getsize,
     ):
         """Gracefully handle size calculation failures when counting new files."""
 
@@ -542,7 +542,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.os.path.getsize")
     @patch("src.sync.sync_photos.sync_photos")
     def test_perform_photos_sync_handles_hardlink_bytes_failure(
-        self, mock_sync_photos, mock_getsize
+        self, mock_sync_photos, mock_getsize,
     ):
         """Handle errors when estimating bytes saved by hardlinks."""
 
@@ -643,7 +643,7 @@ class TestSync(unittest.TestCase):
         self.assertEqual(len(stats.errors), 0)
 
     @patch(
-        "src.sync.notify.send_sync_summary", side_effect=RuntimeError("notify failure")
+        "src.sync.notify.send_sync_summary", side_effect=RuntimeError("notify failure"),
     )
     @patch("src.sync._perform_photos_sync")
     @patch("src.sync._perform_drive_sync", return_value=DriveStats(files_downloaded=1))
@@ -696,7 +696,7 @@ class TestSync(unittest.TestCase):
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
 
         actual = sync.get_api_instance(
-            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD
+            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD,
         )
         self.assertNotIn(".com.cn", actual.home_endpoint)
         self.assertNotIn(".com.cn", actual.setup_endpoint)
@@ -714,7 +714,7 @@ class TestSync(unittest.TestCase):
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
 
         actual = sync.get_api_instance(
-            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD
+            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD,
         )
         self.assertNotIn(".com.cn", actual.home_endpoint)
         self.assertNotIn(".com.cn", actual.setup_endpoint)
@@ -722,7 +722,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -757,9 +757,9 @@ class TestSync(unittest.TestCase):
                     e
                     for e in captured[1]
                     if "retry_login_interval is < 0, exiting ..." in e
-                ]
+                ],
             )
-            > 0
+            > 0,
         )
 
     @patch("src.sync.sleep")
@@ -768,7 +768,7 @@ class TestSync(unittest.TestCase):
         side_effect=exceptions.ICloudPyNoStoredPasswordAvailableException,
     )
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -798,7 +798,7 @@ class TestSync(unittest.TestCase):
         self.assertTrue(len(captured.records) > 1)
         self.assertTrue(
             len([e for e in captured[1] if "Password is not stored in keyring." in e])
-            > 0
+            > 0,
         )
         self.assertTrue(
             len(
@@ -806,9 +806,9 @@ class TestSync(unittest.TestCase):
                     e
                     for e in captured[1]
                     if "retry_login_interval is < 0, exiting ..." in e
-                ]
+                ],
             )
-            > 0
+            > 0,
         )
 
     @patch("src.sync.sync_drive")
@@ -817,7 +817,7 @@ class TestSync(unittest.TestCase):
     @patch("src.usage.alive")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -856,7 +856,7 @@ class TestSync(unittest.TestCase):
                     for e in captured[1]
                     if "All configured sync intervals are negative, exiting oneshot mode..."
                     in e
-                ]
+                ],
             )
             > 0,
         )
@@ -869,7 +869,7 @@ class TestSync(unittest.TestCase):
     @patch("src.usage.alive")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -907,7 +907,7 @@ class TestSync(unittest.TestCase):
                     for e in captured[1]
                     if "All configured sync intervals are negative, exiting oneshot mode..."
                     in e
-                ]
+                ],
             )
             > 0,
         )
@@ -919,7 +919,7 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
     @patch(
-        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER,
     )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
@@ -1037,14 +1037,14 @@ class TestSync(unittest.TestCase):
         sync_state.photos_time_remaining = 86400
 
         # Calculate next sync schedule
-        sleep_for = sync._calculate_next_sync_schedule(
-            config, sync_state
-        )  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
+            config, sync_state,
+        )
 
         # This should NOT be 0 - that's the bug causing immediate re-sync
         # When both timers are equal and both services just ran, we should wait
         self.assertGreater(
-            sleep_for, 0, "Sleep time should not be 0 when both services just completed"
+            sleep_for, 0, "Sleep time should not be 0 when both services just completed",
         )
         self.assertEqual(
             sleep_for,
@@ -1067,17 +1067,17 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 1800  # 30 min remaining
         sync_state.photos_time_remaining = 3600  # 1 hour remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(
-            config, sync_state
-        )  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
+            config, sync_state,
+        )
 
         self.assertEqual(sleep_for, 1800, "Should sleep until drive sync time")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
         self.assertFalse(
-            sync_state.enable_sync_photos, "Photos sync should be disabled"
+            sync_state.enable_sync_photos, "Photos sync should be disabled",
         )
         self.assertEqual(
-            sync_state.photos_time_remaining, 1800, "Photos timer should be reduced"
+            sync_state.photos_time_remaining, 1800, "Photos timer should be reduced",
         )
 
     def test_calculate_next_sync_schedule_photos_first(self):
@@ -1091,15 +1091,15 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 3600  # 1 hour remaining
         sync_state.photos_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(
-            config, sync_state
-        )  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
+            config, sync_state,
+        )
 
         self.assertEqual(sleep_for, 1800, "Should sleep until photos sync time")
         self.assertFalse(sync_state.enable_sync_drive, "Drive sync should be disabled")
         self.assertTrue(sync_state.enable_sync_photos, "Photos sync should be enabled")
         self.assertEqual(
-            sync_state.drive_time_remaining, 1800, "Drive timer should be reduced"
+            sync_state.drive_time_remaining, 1800, "Drive timer should be reduced",
         )
 
     def test_calculate_next_sync_schedule_drive_only(self):
@@ -1111,14 +1111,14 @@ class TestSync(unittest.TestCase):
         sync_state = sync.SyncState()
         sync_state.drive_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(
-            config, sync_state
-        )  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
+            config, sync_state,
+        )
 
         self.assertEqual(sleep_for, 1800, "Should sleep for drive remaining time")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
         self.assertFalse(
-            sync_state.enable_sync_photos, "Photos sync should be disabled"
+            sync_state.enable_sync_photos, "Photos sync should be disabled",
         )
 
     def test_calculate_next_sync_schedule_photos_only(self):
@@ -1130,9 +1130,9 @@ class TestSync(unittest.TestCase):
         sync_state = sync.SyncState()
         sync_state.photos_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(
-            config, sync_state
-        )  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
+            config, sync_state,
+        )
 
         self.assertEqual(sleep_for, 1800, "Should sleep for photos remaining time")
         self.assertFalse(sync_state.enable_sync_drive, "Drive sync should be disabled")
@@ -1150,13 +1150,13 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 0
         sync_state.photos_time_remaining = 0
 
-        sleep_for = sync._calculate_next_sync_schedule(
-            config, sync_state
-        )  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
+            config, sync_state,
+        )
 
         # Should have 0 sleep (immediate sync) but only drive should be enabled
         self.assertEqual(
-            sleep_for, 0, "Should have immediate sync when both timers are 0"
+            sleep_for, 0, "Should have immediate sync when both timers are 0",
         )
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
         self.assertFalse(
@@ -1176,13 +1176,13 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 5
         sync_state.photos_time_remaining = 5
 
-        sleep_for = sync._calculate_next_sync_schedule(
-            config, sync_state
-        )  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(  # noqa: SLF001
+            config, sync_state,
+        )
 
         # Should use original logic for small timers: sleep_for = 0, only drive enabled
         self.assertEqual(sleep_for, 0, "Should have 0 sleep for small equal timers")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
         self.assertFalse(
-            sync_state.enable_sync_photos, "Photos sync should be disabled"
+            sync_state.enable_sync_photos, "Photos sync should be disabled",
         )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -38,14 +38,18 @@ class TestSync(unittest.TestCase):
         self.root_dir = tests.TEMP_DIR
         self.config["app"]["root"] = self.root_dir
         os.makedirs(tests.TEMP_DIR, exist_ok=True)
-        self.service = data.ICloudPyServiceMock(data.AUTHENTICATED_USER, data.VALID_PASSWORD)
+        self.service = data.ICloudPyServiceMock(
+            data.AUTHENTICATED_USER, data.VALID_PASSWORD
+        )
 
     def tearDown(self) -> None:
         """Remove temp directories."""
         self.remove_temp()
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -63,10 +67,16 @@ class TestSync(unittest.TestCase):
         if ENV_ICLOUD_PASSWORD_KEY in os.environ:
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
         self.assertIsNone(sync.sync())
-        self.assertTrue(os.path.isdir("/config/session_data"))
+        # Resolves to the conftest's tempdir (or /config/session_data
+        # in a real container deployment).
+        from src import DEFAULT_COOKIE_DIRECTORY
+
+        self.assertTrue(os.path.isdir(DEFAULT_COOKIE_DIRECTORY))
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -89,10 +99,14 @@ class TestSync(unittest.TestCase):
         self.assertIsNone(sync.sync())
         dir_length = len(os.listdir(self.root_dir))
         self.assertTrue(dir_length == 1)
-        self.assertTrue(os.path.isdir(os.path.join(self.root_dir, config["photos"]["destination"])))
+        self.assertTrue(
+            os.path.isdir(os.path.join(self.root_dir, config["photos"]["destination"]))
+        )
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -114,12 +128,16 @@ class TestSync(unittest.TestCase):
         self.remove_temp()
         mock_read_config.return_value = config
         self.assertIsNone(sync.sync())
-        self.assertTrue(os.path.isdir(os.path.join(self.root_dir, config["drive"]["destination"])))
+        self.assertTrue(
+            os.path.isdir(os.path.join(self.root_dir, config["drive"]["destination"]))
+        )
         dir_length = len(os.listdir(self.root_dir))
         self.assertTrue(dir_length == 1)
 
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -146,7 +164,9 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -178,7 +198,9 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -209,7 +231,8 @@ class TestSync(unittest.TestCase):
                     [
                         e
                         for e in captured[1]
-                        if "Password is not stored in keyring. Please save the password in keyring." in e
+                        if "Password is not stored in keyring. Please save the password in keyring."
+                        in e
                     ],
                 )
                 > 0,
@@ -241,11 +264,22 @@ class TestSync(unittest.TestCase):
             with patch.dict(os.environ, {ENV_ICLOUD_PASSWORD_KEY: data.VALID_PASSWORD}):
                 with self.assertRaises(Exception):
                     sync.sync()
-                self.assertTrue(len([e for e in captured[1] if "Error: 2FA is required. Please log in." in e]) > 0)
+                self.assertTrue(
+                    len(
+                        [
+                            e
+                            for e in captured[1]
+                            if "Error: 2FA is required. Please log in." in e
+                        ]
+                    )
+                    > 0
+                )
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -274,7 +308,9 @@ class TestSync(unittest.TestCase):
     @patch(target="sys.stdout", new_callable=StringIO)
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -383,7 +419,9 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.os.path.getsize", side_effect=RuntimeError("size failure"))
     @patch("src.sync.sync_drive")
-    def test_perform_drive_sync_handles_getsize_failure(self, mock_sync_drive, _mock_getsize):
+    def test_perform_drive_sync_handles_getsize_failure(
+        self, mock_sync_drive, _mock_getsize
+    ):
         """Gracefully handle size calculation failures when counting new files."""
 
         sync_state = sync.SyncState()
@@ -503,7 +541,9 @@ class TestSync(unittest.TestCase):
 
     @patch("src.sync.os.path.getsize")
     @patch("src.sync.sync_photos.sync_photos")
-    def test_perform_photos_sync_handles_hardlink_bytes_failure(self, mock_sync_photos, mock_getsize):
+    def test_perform_photos_sync_handles_hardlink_bytes_failure(
+        self, mock_sync_photos, mock_getsize
+    ):
         """Handle errors when estimating bytes saved by hardlinks."""
 
         class TrackingSet(set):
@@ -602,11 +642,15 @@ class TestSync(unittest.TestCase):
         self.assertFalse(stats.has_errors())
         self.assertEqual(len(stats.errors), 0)
 
-
-    @patch("src.sync.notify.send_sync_summary", side_effect=RuntimeError("notify failure"))
+    @patch(
+        "src.sync.notify.send_sync_summary", side_effect=RuntimeError("notify failure")
+    )
     @patch("src.sync._perform_photos_sync")
     @patch("src.sync._perform_drive_sync", return_value=DriveStats(files_downloaded=1))
-    @patch("src.sync._authenticate_and_get_api", return_value=SimpleNamespace(requires_2sa=False))
+    @patch(
+        "src.sync._authenticate_and_get_api",
+        return_value=SimpleNamespace(requires_2sa=False),
+    )
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
     def test_sync_summary_notification_failure_logged(
@@ -633,7 +677,10 @@ class TestSync(unittest.TestCase):
 
         mock_notify.assert_called()
         self.assertTrue(
-            any("Failed to send sync summary notification" in message for message in captured_logs.output),
+            any(
+                "Failed to send sync summary notification" in message
+                for message in captured_logs.output
+            ),
         )
 
     @patch("src.sync.read_config")
@@ -648,7 +695,9 @@ class TestSync(unittest.TestCase):
         if ENV_ICLOUD_PASSWORD_KEY in os.environ:
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
 
-        actual = sync.get_api_instance(username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD)
+        actual = sync.get_api_instance(
+            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD
+        )
         self.assertNotIn(".com.cn", actual.home_endpoint)
         self.assertNotIn(".com.cn", actual.setup_endpoint)
 
@@ -664,13 +713,17 @@ class TestSync(unittest.TestCase):
         if ENV_ICLOUD_PASSWORD_KEY in os.environ:
             del os.environ[ENV_ICLOUD_PASSWORD_KEY]
 
-        actual = sync.get_api_instance(username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD)
+        actual = sync.get_api_instance(
+            username=data.AUTHENTICATED_USER, password=data.VALID_PASSWORD
+        )
         self.assertNotIn(".com.cn", actual.home_endpoint)
         self.assertNotIn(".com.cn", actual.setup_endpoint)
 
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -698,14 +751,25 @@ class TestSync(unittest.TestCase):
             sync.sync()
         self.assertTrue(len(captured.records) > 1)
         self.assertTrue(len([e for e in captured[1] if "2FA is required" in e]) > 0)
-        self.assertTrue(len([e for e in captured[1] if "retry_login_interval is < 0, exiting ..." in e]) > 0)
+        self.assertTrue(
+            len(
+                [
+                    e
+                    for e in captured[1]
+                    if "retry_login_interval is < 0, exiting ..." in e
+                ]
+            )
+            > 0
+        )
 
     @patch("src.sync.sleep")
     @patch(
         target="keyring.get_password",
         side_effect=exceptions.ICloudPyNoStoredPasswordAvailableException,
     )
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -732,15 +796,29 @@ class TestSync(unittest.TestCase):
             ]
             sync.sync()
         self.assertTrue(len(captured.records) > 1)
-        self.assertTrue(len([e for e in captured[1] if "Password is not stored in keyring." in e]) > 0)
-        self.assertTrue(len([e for e in captured[1] if "retry_login_interval is < 0, exiting ..." in e]) > 0)
+        self.assertTrue(
+            len([e for e in captured[1] if "Password is not stored in keyring." in e])
+            > 0
+        )
+        self.assertTrue(
+            len(
+                [
+                    e
+                    for e in captured[1]
+                    if "retry_login_interval is < 0, exiting ..." in e
+                ]
+            )
+            > 0
+        )
 
     @patch("src.sync.sync_drive")
     @patch("src.sync.sync_photos")
     @patch("src.sync.sleep")
     @patch("src.usage.alive")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -772,7 +850,14 @@ class TestSync(unittest.TestCase):
         # Verify the container exits with oneshot message
         self.assertTrue(len(captured.records) > 1)
         self.assertTrue(
-            len([e for e in captured[1] if "All configured sync intervals are negative, exiting oneshot mode..." in e])
+            len(
+                [
+                    e
+                    for e in captured[1]
+                    if "All configured sync intervals are negative, exiting oneshot mode..."
+                    in e
+                ]
+            )
             > 0,
         )
         # Verify sleep is never called (container exits immediately after sync)
@@ -783,7 +868,9 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sleep")
     @patch("src.usage.alive")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -814,7 +901,14 @@ class TestSync(unittest.TestCase):
         # Verify the container exits with oneshot message
         self.assertTrue(len(captured.records) > 1)
         self.assertTrue(
-            len([e for e in captured[1] if "All configured sync intervals are negative, exiting oneshot mode..." in e])
+            len(
+                [
+                    e
+                    for e in captured[1]
+                    if "All configured sync intervals are negative, exiting oneshot mode..."
+                    in e
+                ]
+            )
             > 0,
         )
         # Verify sleep is never called
@@ -824,7 +918,9 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.sync_photos")
     @patch("src.sync.sleep")
     @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
-    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch(
+        target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER
+    )
     @patch("icloudpy.ICloudPyService")
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
@@ -858,7 +954,10 @@ class TestSync(unittest.TestCase):
 
         # Verify it does NOT exit with oneshot message
         oneshot_messages = [
-            e for e in captured[1] if "All configured sync intervals are negative, exiting oneshot mode..." in e
+            e
+            for e in captured[1]
+            if "All configured sync intervals are negative, exiting oneshot mode..."
+            in e
         ]
         self.assertEqual(len(oneshot_messages), 0)
         # Verify sleep was called (indicating the loop continued)
@@ -867,7 +966,10 @@ class TestSync(unittest.TestCase):
     @patch("src.sync.notify.send_sync_summary")
     @patch("src.sync._perform_photos_sync", return_value=None)
     @patch("src.sync._perform_drive_sync", return_value=DriveStats(files_downloaded=1))
-    @patch("src.sync._authenticate_and_get_api", return_value=SimpleNamespace(requires_2sa=False))
+    @patch(
+        "src.sync._authenticate_and_get_api",
+        return_value=SimpleNamespace(requires_2sa=False),
+    )
     @patch("src.sync.read_config")
     @patch("requests.post", side_effect=tests.mocked_usage_post)
     def test_sync_notification_not_sent_when_both_services_not_synced(
@@ -935,12 +1037,20 @@ class TestSync(unittest.TestCase):
         sync_state.photos_time_remaining = 86400
 
         # Calculate next sync schedule
-        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(
+            config, sync_state
+        )  # noqa: SLF001
 
         # This should NOT be 0 - that's the bug causing immediate re-sync
         # When both timers are equal and both services just ran, we should wait
-        self.assertGreater(sleep_for, 0, "Sleep time should not be 0 when both services just completed")
-        self.assertEqual(sleep_for, 86400, "Should wait for the full interval when both services have equal timers")
+        self.assertGreater(
+            sleep_for, 0, "Sleep time should not be 0 when both services just completed"
+        )
+        self.assertEqual(
+            sleep_for,
+            86400,
+            "Should wait for the full interval when both services have equal timers",
+        )
 
         # When timers are equal and > 10 seconds, both services should be enabled for next sync
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
@@ -957,12 +1067,18 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 1800  # 30 min remaining
         sync_state.photos_time_remaining = 3600  # 1 hour remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(
+            config, sync_state
+        )  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep until drive sync time")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled")
-        self.assertEqual(sync_state.photos_time_remaining, 1800, "Photos timer should be reduced")
+        self.assertFalse(
+            sync_state.enable_sync_photos, "Photos sync should be disabled"
+        )
+        self.assertEqual(
+            sync_state.photos_time_remaining, 1800, "Photos timer should be reduced"
+        )
 
     def test_calculate_next_sync_schedule_photos_first(self):
         """Test that photos syncs first when its timer is smaller."""
@@ -975,12 +1091,16 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 3600  # 1 hour remaining
         sync_state.photos_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(
+            config, sync_state
+        )  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep until photos sync time")
         self.assertFalse(sync_state.enable_sync_drive, "Drive sync should be disabled")
         self.assertTrue(sync_state.enable_sync_photos, "Photos sync should be enabled")
-        self.assertEqual(sync_state.drive_time_remaining, 1800, "Drive timer should be reduced")
+        self.assertEqual(
+            sync_state.drive_time_remaining, 1800, "Drive timer should be reduced"
+        )
 
     def test_calculate_next_sync_schedule_drive_only(self):
         """Test scheduling when only drive is configured."""
@@ -991,11 +1111,15 @@ class TestSync(unittest.TestCase):
         sync_state = sync.SyncState()
         sync_state.drive_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(
+            config, sync_state
+        )  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep for drive remaining time")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled")
+        self.assertFalse(
+            sync_state.enable_sync_photos, "Photos sync should be disabled"
+        )
 
     def test_calculate_next_sync_schedule_photos_only(self):
         """Test scheduling when only photos is configured."""
@@ -1006,7 +1130,9 @@ class TestSync(unittest.TestCase):
         sync_state = sync.SyncState()
         sync_state.photos_time_remaining = 1800  # 30 min remaining
 
-        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(
+            config, sync_state
+        )  # noqa: SLF001
 
         self.assertEqual(sleep_for, 1800, "Should sleep for photos remaining time")
         self.assertFalse(sync_state.enable_sync_drive, "Drive sync should be disabled")
@@ -1024,12 +1150,19 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 0
         sync_state.photos_time_remaining = 0
 
-        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(
+            config, sync_state
+        )  # noqa: SLF001
 
         # Should have 0 sleep (immediate sync) but only drive should be enabled
-        self.assertEqual(sleep_for, 0, "Should have immediate sync when both timers are 0")
+        self.assertEqual(
+            sleep_for, 0, "Should have immediate sync when both timers are 0"
+        )
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled for first sync")
+        self.assertFalse(
+            sync_state.enable_sync_photos,
+            "Photos sync should be disabled for first sync",
+        )
 
     def test_calculate_next_sync_schedule_equal_small_timers(self):
         """Test scheduling when both timers are equal but small (≤ 10 seconds)."""
@@ -1043,9 +1176,13 @@ class TestSync(unittest.TestCase):
         sync_state.drive_time_remaining = 5
         sync_state.photos_time_remaining = 5
 
-        sleep_for = sync._calculate_next_sync_schedule(config, sync_state)  # noqa: SLF001
+        sleep_for = sync._calculate_next_sync_schedule(
+            config, sync_state
+        )  # noqa: SLF001
 
         # Should use original logic for small timers: sleep_for = 0, only drive enabled
         self.assertEqual(sleep_for, 0, "Should have 0 sleep for small equal timers")
         self.assertTrue(sync_state.enable_sync_drive, "Drive sync should be enabled")
-        self.assertFalse(sync_state.enable_sync_photos, "Photos sync should be disabled")
+        self.assertFalse(
+            sync_state.enable_sync_photos, "Photos sync should be disabled"
+        )


### PR DESCRIPTION
## Summary
The test suite assumed `/config` exists and is writable. On macOS dev
hosts and any sandbox where the container's `/config` mount isn't
present, ~20 tests fail with `FileNotFoundError` on usage cache
writes, session-data cookie directory creation, or hardcoded
`/config/...` path assertions.

This makes TDD on the codebase painful — `pytest` is red on a
healthy local checkout, drowning real failures in noise. CI in
container passes because `/config` is writable inside.

## Fix
- `src/__init__.py` + `src/usage.py`: `ICLOUD_DOCKER_CONFIG_DIR` env
  var overrides the `/config` base. Defaults to `/config` so
  production container deployments are unchanged.
- `src/sync.py`: `get_api_instance()` late-binds the `cookie_directory`
  default (was captured at function-definition time, which made
  conftest redirects ineffective).
- `tests/conftest.py`: NEW session-wide fixture redirects
  `ICLOUD_DOCKER_CONFIG_DIR` to a tempdir, patches the cached
  constants, cleans up at session end.
- `tests/test_sync.py`: assertion uses the resolved
  `DEFAULT_COOKIE_DIRECTORY` instead of hardcoded
  `/config/session_data`.

## Validation
- macOS dev host: **435 / 435 tests pass** on this branch (up from
  ~415 / 435 with 20 pre-existing failures on bare main).
- Linux/CI: no change — `ICLOUD_DOCKER_CONFIG_DIR` is unset, falls
  back to `/config`, all original behaviour preserved.
- Production deployments: zero behavior change — paths still resolve
  to `/config/...` in the container.

## Backward compatibility
- Existing production installs: completely unchanged. The env var is
  only set in test environments where `/config` isn't writable.
- Test environments that already use a `/config` mount: opt-in by
  not setting `ICLOUD_DOCKER_CONFIG_DIR`. Fixture honours explicit
  caller override.
