### PR TITLE
Update icloudpy version to 0.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-icloudpy==0.8.0
+icloudpy==0.9.0
 ruamel.yaml==0.19.1
 python-magic==0.4.27
 requests~=2.32.3


### PR DESCRIPTION
# icloudpy==0.9.0 release:

**FEATURE**: surface Live Photo .mov pair via versions (enables fixing https://github.com/mandarons/icloud-docker/issues/199) by @epheterson in https://github.com/mandarons/icloudpy/pull/139
**BUGFIX**: trigger 2FA push notification on iOS 26.4+ (resolves the auth stall in https://github.com/mandarons/icloud-docker/issues/426) by @epheterson in https://github.com/mandarons/icloudpy/pull/138
**FEATURE**: PhotoAlbum.iter_chunks — fixed-size batches for bounded-memory bulk download (moves icloud-docker#462 up) by @epheterson in https://github.com/mandarons/icloudpy/pull/140