### PR TITLE
fix: resolve keyring disconnect from PR #460 causing 'Password not stored in keyring'

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -127,9 +127,8 @@ source .venv/bin/activate && ./run-ci.sh
 ### Container Integration
 - **User management**: Runs as `abc` user (PUID/PGID configurable via env vars)
 - **Volume mounts**:
-  - `/config` → config.yaml + session_data/
+  - `/config` → config.yaml + session_data/ + python_keyring/ (auto-persisted)
   - `/icloud` → synced content (drive/ and photos/)
-  - `/home/abc/.local` → Optional keyring persistence
 - **Session persistence**: Authentication tokens in `/config/session_data` (iCloudPy cookie directory)
 - **Init sequence**: `docker-entrypoint.sh` → sets UID/GID → `su-exec abc /app/init.sh` → `python src/main.py`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ LABEL maintainer="mandarons"
 
 # Set environment variables
 ENV HOME="/app"
+ENV XDG_DATA_HOME="/config"
 ENV PUID=911
 ENV PGID=911
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${PWD}/icloud:/icloud
       - ${PWD}/config:/config # Must contain config.yaml
-      - ${PWD}/keyring:/home/abc/.local # Optional: Persist keyring for credentials (no password re-entry on container recreation)
 ```
 
 ### Authentication (required after container creation or authentication expiration)
@@ -350,14 +349,13 @@ This guide helps you set up iCloud sync on a UGREEN NAS system using Docker.
 
    Create the following directory structure in your UGREEN user directory:
    ```
-   /Cloud-Drives/
-   ├── Google-Drive
-   ├── iCloud
-   │   ├── Data
-   │   ├── Config
-   │   │   └── config.yaml (see step 2)
-   │   └── keyring
-   └── OneDrive
+    /Cloud-Drives/
+    ├── Google-Drive
+    ├── iCloud
+    │   ├── Data
+    │   └── Config
+    │       └── config.yaml (see step 2)
+    └── OneDrive
    ```
 
 2. **Create config file**
@@ -383,9 +381,8 @@ This guide helps you set up iCloud sync on a UGREEN NAS system using Docker.
        volumes:
          - /etc/timezone:/etc/timezone:ro
          - /etc/localtime:/etc/localtime:ro
-         - /home/<ugreen_username>/Cloud-Drives/iCloud/Data:/icloud
-         - /home/<ugreen_username>/Cloud-Drives/iCloud/Config:/config
-         - /home/<ugreen_username>/Cloud-Drives/iCloud/keyring:/home/abc/.local # Optional: Persist keyring for credentials (no password re-entry on container recreation)
+          - /home/<ugreen_username>/Cloud-Drives/iCloud/Data:/icloud
+          - /home/<ugreen_username>/Cloud-Drives/iCloud/Config:/config
    ```
 
    Replace `<ugreen_username>` with your UGREEN system username.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,19 +29,16 @@ fi
 # Create necessary directories
 mkdir -p /icloud /config/session_data /home/abc /config/python_keyring
 
-# Persist python-keyring across container recreations.
-# python-keyring's `keyrings.alt` file backend stores its passwords in
-# `$XDG_DATA_HOME/python_keyring/keyring_pass.cfg`. Default $XDG_DATA_HOME
-# is `$HOME/.local/share` — inside the container, so every `docker compose up`
-# (or PUID change, or image bump) wipes the cached Apple ID password and
-# the user has to re-authenticate. Pointing XDG_DATA_HOME at the bind-mounted
-# /config makes the keyring file persist for the life of the volume.
-export XDG_DATA_HOME=/config
-# /config/python_keyring is created above as root; the conditional chown
-# block below skips /config when it's already owned by abc (common on
-# bind-mounted hosts) and would leave the new subdir root-owned and
-# unwritable. Always chown the keyring dir specifically.
-chown abc:abc /config/python_keyring 2>/dev/null || true
+# Migrate python-keyring from old location to new if needed.
+# PR #460 moved keyring to /config/python_keyring via XDG_DATA_HOME=/config
+# (set in Dockerfile). Users who had keyring at the old location
+# ($HOME/.local/share/python_keyring/) need it copied to the new path.
+OLD_KEYRING="/home/abc/.local/share/python_keyring/keyring_pass.cfg"
+NEW_KEYRING="/config/python_keyring/keyring_pass.cfg"
+if [ -f "$OLD_KEYRING" ] && [ ! -f "$NEW_KEYRING" ]; then
+    echo "Migrating keyring from $OLD_KEYRING to $NEW_KEYRING"
+    cp "$OLD_KEYRING" "$NEW_KEYRING"
+fi
 
 # Set ownership if not already correct
 for dir in /app /config /icloud /home/abc; do

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -3,7 +3,9 @@
 __author__ = "Mandar Patil (mandarons@pm.me)"
 
 import os
+import shutil
 import subprocess
+import tempfile
 import unittest
 
 
@@ -29,6 +31,76 @@ class TestDockerEntrypoint(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.returncode, 0, f"Script syntax error: {result.stderr}")
+
+
+class TestKeyringMigration(unittest.TestCase):
+    """Tests for keyring migration from old to new location."""
+
+    MIGRATION_SNIPPET = """\
+OLD_KEYRING="{old}"
+NEW_KEYRING="{new}"
+if [ -f "$OLD_KEYRING" ] && [ ! -f "$NEW_KEYRING" ]; then
+    mkdir -p "$(dirname "$NEW_KEYRING")"
+    cp "$OLD_KEYRING" "$NEW_KEYRING"
+fi
+"""
+
+    def setUp(self):
+        """Create temporary directories for test isolation."""
+        self.tmpdir = tempfile.mkdtemp()
+        self.old_dir = os.path.join(self.tmpdir, "old_keyring")
+        self.new_dir = os.path.join(self.tmpdir, "new_keyring")
+        self.old_keyring = os.path.join(self.old_dir, "keyring_pass.cfg")
+        self.new_keyring = os.path.join(self.new_dir, "keyring_pass.cfg")
+
+    def tearDown(self):
+        """Clean up temporary directories."""
+        shutil.rmtree(self.tmpdir)
+
+    def _run_migration(self):
+        """Run the migration snippet with test paths."""
+        snippet = self.MIGRATION_SNIPPET.format(old=self.old_keyring, new=self.new_keyring)
+        result = subprocess.run(["sh", "-c", snippet], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, f"Migration snippet failed: {result.stderr}")
+
+    def test_migration_from_old_location(self):
+        """Test that keyring is copied when old exists and new doesn't."""
+        os.makedirs(self.old_dir)
+        with open(self.old_keyring, "w") as f:
+            f.write("test_password_data")
+
+        self._run_migration()
+
+        self.assertTrue(os.path.exists(self.new_keyring))
+        with open(self.new_keyring) as f:
+            self.assertEqual(f.read(), "test_password_data")
+
+    def test_no_migration_when_new_keyring_exists(self):
+        """Test that old keyring is NOT copied when new already exists."""
+        os.makedirs(self.old_dir)
+        os.makedirs(self.new_dir)
+        with open(self.old_keyring, "w") as f:
+            f.write("old_password_data")
+        with open(self.new_keyring, "w") as f:
+            f.write("new_password_data")
+
+        self._run_migration()
+
+        with open(self.new_keyring) as f:
+            self.assertEqual(f.read(), "new_password_data")
+
+    def test_no_migration_when_old_keyring_missing(self):
+        """Test that no file is created when old keyring doesn't exist."""
+        self._run_migration()
+
+        self.assertFalse(os.path.exists(self.new_keyring))
+
+    def test_no_migration_when_neither_exists(self):
+        """Test that no error occurs when neither keyring exists."""
+        self._run_migration()
+
+        self.assertFalse(os.path.exists(self.old_keyring))
+        self.assertFalse(os.path.exists(self.new_keyring))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #489. PR #460 moved the python-keyring storage to `/config/python_keyring/` via `export XDG_DATA_HOME=/config` in the entrypoint script. However, this runtime `export` is **not inherited** by `docker exec` processes — Docker passes the container's base environment (Dockerfile `ENV` + docker-compose `environment:`), not runtime modifications from the entrypoint.

This creates a permanent disconnect:

| Process | Has `XDG_DATA_HOME=/config`? | Keyring location |
|---|---|---|
| Sync loop (PID 1) | Yes (inherited from entrypoint `export`) | `/config/python_keyring/` — **empty** |
| `docker exec` (icloud CLI) | **No** | `/home/abc/.local/share/python_keyring/` — has the password |

The sync loop never finds the password, so users see: *"Password is not stored in keyring. Please save the password in keyring."*

## Fix

### Root cause fix — move `XDG_DATA_HOME` to Dockerfile `ENV`

**`Dockerfile`**: Added `ENV XDG_DATA_HOME="/config"` to the runtime stage. This makes the variable part of the container's base environment so all processes — including `docker exec` — inherit it correctly.

### One-time migration — copy old keyring to new location

**`docker-entrypoint.sh`**: Replaced the `export XDG_DATA_HOME=/config` + `chown` block with migration logic that checks for an existing keyring at the old path (`/home/abc/.local/share/python_keyring/keyring_pass.cfg`) and copies it to the new path (`/config/python_keyring/keyring_pass.cfg`) if the new path is empty. This runs transparently on first container start after upgrade.

### Documentation — remove stale volume mount

**`README.md`**, **`.github/copilot-instructions.md`**: Removed the `${PWD}/keyring:/home/abc/.local` volume mount recommendation from all examples (docker-compose, UGREEN NAS setup, folder structure). The keyring is now auto-persisted inside the `/config` volume at `/config/python_keyring/`.

### Tests

**`tests/test_docker_entrypoint.py`**: Added `TestKeyringMigration` class with 4 test cases:
- Migration copies old keyring to new location
- No overwrite when new keyring already exists
- No file created when old keyring is missing
- No error when neither location has a keyring

## Validation

- All 458 tests pass (100% coverage maintained)
- Ruff linting clean
- Entrypoint shell syntax valid