### PR TITLE
fix(photos): re-fetch master record on 410 instead of clearing cached versions

### DIFF
--- a/src/photo_file_utils.py
+++ b/src/photo_file_utils.py
@@ -6,10 +6,12 @@ downloading, hardlink creation, and file existence checking.
 
 ___author___ = "Mandar Patil <mandarons@pm.me>"
 
+import json
 import os
 import shutil
 import threading
 from datetime import timezone
+from urllib.parse import urlencode
 
 from src import get_logger
 
@@ -17,6 +19,194 @@ LOGGER = get_logger()
 
 # Module-level lock to protect thread-safe mutation of photo._versions during retries
 _versions_refresh_lock = threading.Lock()
+
+# CloudKit fields to request when re-fetching a photo record for fresh download URLs.
+# Mirrors the desiredKeys list used by icloudpy's PhotoAlbum._list_query_gen().
+_DESIRED_KEYS = [
+    "resJPEGFullWidth",
+    "resJPEGFullHeight",
+    "resJPEGFullFileType",
+    "resJPEGFullFingerprint",
+    "resJPEGFullRes",
+    "resJPEGLargeWidth",
+    "resJPEGLargeHeight",
+    "resJPEGLargeFileType",
+    "resJPEGLargeFingerprint",
+    "resJPEGLargeRes",
+    "resJPEGMedWidth",
+    "resJPEGMedHeight",
+    "resJPEGMedFileType",
+    "resJPEGMedFingerprint",
+    "resJPEGMedRes",
+    "resJPEGThumbWidth",
+    "resJPEGThumbHeight",
+    "resJPEGThumbFileType",
+    "resJPEGThumbFingerprint",
+    "resJPEGThumbRes",
+    "resVidFullWidth",
+    "resVidFullHeight",
+    "resVidFullFileType",
+    "resVidFullFingerprint",
+    "resVidFullRes",
+    "resVidMedWidth",
+    "resVidMedHeight",
+    "resVidMedFileType",
+    "resVidMedFingerprint",
+    "resVidMedRes",
+    "resVidSmallWidth",
+    "resVidSmallHeight",
+    "resVidSmallFileType",
+    "resVidSmallFingerprint",
+    "resVidSmallRes",
+    "resSidecarWidth",
+    "resSidecarHeight",
+    "resSidecarFileType",
+    "resSidecarFingerprint",
+    "resSidecarRes",
+    "itemType",
+    "dataClassType",
+    "filenameEnc",
+    "originalOrientation",
+    "resOriginalWidth",
+    "resOriginalHeight",
+    "resOriginalFileType",
+    "resOriginalFingerprint",
+    "resOriginalRes",
+    "resOriginalAltWidth",
+    "resOriginalAltHeight",
+    "resOriginalAltFileType",
+    "resOriginalAltFingerprint",
+    "resOriginalAltRes",
+    "resOriginalVidComplWidth",
+    "resOriginalVidComplHeight",
+    "resOriginalVidComplFileType",
+    "resOriginalVidComplFingerprint",
+    "resOriginalVidComplRes",
+    "isDeleted",
+    "isExpunged",
+    "dateExpunged",
+    "remappedRef",
+    "recordName",
+    "recordType",
+    "recordChangeTag",
+    "masterRef",
+    "adjustmentRenderType",
+    "assetDate",
+    "addedDate",
+    "isFavorite",
+    "isHidden",
+    "orientation",
+    "duration",
+    "assetSubtype",
+    "assetSubtypeV2",
+    "assetHDRType",
+    "burstFlags",
+    "burstFlagsExt",
+    "burstId",
+    "captionEnc",
+    "extendedDescEnc",
+    "locationEnc",
+    "locationV2Enc",
+    "locationLatitude",
+    "locationLongitude",
+    "adjustmentType",
+    "timeZoneOffset",
+    "vidComplDurValue",
+    "vidComplDurScale",
+    "vidComplDispValue",
+    "vidComplDispScale",
+    "vidComplVisibilityState",
+    "customRenderedValue",
+    "containerId",
+    "itemId",
+    "position",
+    "isKeyAsset",
+    "importedByBundleIdentifierEnc",
+    "importedByDisplayNameEnc",
+    "importedBy",
+]
+
+
+def _refresh_photo_download_url(photo) -> bool:
+    """Re-fetch the photo's master record from iCloud to obtain fresh download URLs.
+
+    iCloud download URLs are signed CDN tokens that expire after ~30–40 minutes.
+    When a URL expires (HTTP 410 Gone), clearing ``photo._versions`` alone is
+    insufficient because icloudpy re-parses the same stale ``_master_record``
+    which still contains the expired URL.  This function makes a new
+    ``records/query`` API call to get an updated master record with fresh URLs,
+    then updates ``photo._master_record`` in place and clears ``_versions`` so
+    the next ``download()`` call uses the fresh URL.
+
+    Args:
+        photo: PhotoAsset object from icloudpy
+
+    Returns:
+        True if the master record was successfully refreshed, False otherwise.
+    """
+    try:
+        record_name = photo._master_record["recordName"]  # noqa: SLF001
+        record_type = photo._master_record.get("recordType", "CPLMaster")  # noqa: SLF001
+    except (AttributeError, KeyError, TypeError):
+        LOGGER.debug("Cannot refresh download URL: photo missing _master_record or recordName")
+        return False
+
+    service = getattr(photo, "_service", None)
+    if service is None:
+        LOGGER.debug("Cannot refresh download URL: photo missing _service")
+        return False
+
+    endpoint = getattr(service, "_service_endpoint", None)
+    session = getattr(service, "session", None)
+    params = getattr(service, "params", None)
+    zone_id = getattr(service, "zone_id", None)
+
+    if not all([endpoint, session, params, zone_id]):
+        LOGGER.debug("Cannot refresh download URL: photo._service missing required attributes")
+        return False
+
+    try:
+        url = f"{endpoint}/records/query?{urlencode(params)}"
+        query = {
+            "query": {
+                "recordType": record_type,
+                "filterBy": [
+                    {
+                        "fieldName": "recordName",
+                        "comparator": "IN",
+                        "fieldValue": {
+                            "type": "STRING_LIST",
+                            "value": [record_name],
+                        },
+                    },
+                ],
+            },
+            "resultsLimit": 1,
+            "desiredKeys": _DESIRED_KEYS,
+            "zoneID": zone_id,
+        }
+        request = session.post(
+            url,
+            data=json.dumps(query),
+            headers={"Content-type": "text/plain"},
+        )
+        response = request.json()
+        records = response.get("records", [])
+
+        for rec in records:
+            if rec.get("recordName") == record_name:
+                photo._master_record = rec  # noqa: SLF001
+                with _versions_refresh_lock:
+                    photo._versions = None  # noqa: SLF001
+                LOGGER.debug(f"Refreshed download URL for {record_name}")
+                return True
+
+        LOGGER.debug(f"Record {record_name} not found in iCloud response during URL refresh")
+        return False
+
+    except Exception as e:  # noqa: BLE001
+        LOGGER.debug(f"Failed to refresh download URL for {record_name}: {e!s}")
+        return False
 
 
 def check_photo_exists(photo, file_size: str, local_path: str) -> bool:
@@ -71,7 +261,8 @@ def download_photo_from_server(photo, file_size: str, destination_path: str, max
 
     This function implements automatic retry logic for HTTP 410 (Gone) errors,
     which occur when iCloud download URLs expire. When a 410 error is detected,
-    the function clears the cached URLs and retries the download.
+    the function re-fetches the photo's master record from iCloud to obtain
+    fresh download URLs, then retries the download.
 
     Args:
         photo: Photo object from iCloudPy
@@ -121,12 +312,10 @@ def download_photo_from_server(photo, file_size: str, destination_path: str, max
                         f"Download URL expired (410) for {destination_path}. "
                         f"Refreshing URL and retrying (attempt {attempt}/{max_attempts})...",
                     )
-                    # Clear cached versions to force URL refresh on next download attempt
-                    # This is necessary because iCloudPy caches the download URLs in _versions
-                    # Lock is used to prevent concurrent _versions mutation from parallel threads
-                    with _versions_refresh_lock:
-                        if hasattr(photo, "_versions"):
-                            photo._versions = None  # noqa: SLF001
+                    # Re-fetch the master record from iCloud to obtain fresh download URLs.
+                    # Simply clearing _versions is insufficient because icloudpy re-parses
+                    # the same stale _master_record which still contains the expired URL.
+                    _refresh_photo_download_url(photo)
                     continue
                 else:
                     LOGGER.error(

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -2008,6 +2008,245 @@ class TestSyncPhotos(unittest.TestCase):
             self.assertFalse(result)
             self.assertEqual(mock_photo.download.call_count, 1)  # Only initial attempt, no retries
 
+    def test_refresh_photo_download_url_success(self):
+        """Test _refresh_photo_download_url successfully refreshes master record."""
+        from unittest.mock import MagicMock, Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock()
+        mock_photo._master_record = {  # noqa: SLF001
+            "recordName": "test-record-123",
+            "recordType": "CPLMaster",
+            "fields": {},
+        }
+        mock_photo._versions = {"original": {"url": "http://expired.url"}}  # noqa: SLF001
+
+        # Mock service with required attributes
+        mock_service = Mock()
+        mock_service._service_endpoint = "https://cv.icloud.com"  # noqa: SLF001
+        mock_service.zone_id = {"zoneName": "PrimarySync"}  # noqa: SLF001
+        mock_service.params = {"auth": "token"}  # noqa: SLF001
+        mock_photo._service = mock_service  # noqa: SLF001
+
+        # Mock API response with fresh record
+        fresh_record = {
+            "recordName": "test-record-123",
+            "recordType": "CPLMaster",
+            "fields": {
+                "resOriginalRes": {
+                    "value": {
+                        "downloadURL": "https://fresh-url.example.com/photo.jpg",
+                        "size": 12345,
+                    },
+                },
+            },
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"records": [fresh_record]}
+        mock_service.session.post.return_value = mock_response
+
+        result = _refresh_photo_download_url(mock_photo)
+
+        self.assertTrue(result)
+        # Verify master record was updated
+        self.assertEqual(mock_photo._master_record, fresh_record)  # noqa: SLF001
+        # Verify _versions was cleared
+        self.assertIsNone(mock_photo._versions)  # noqa: SLF001
+        # Verify API was called
+        mock_service.session.post.assert_called_once()
+
+    def test_refresh_photo_download_url_missing_master_record(self):
+        """Test _refresh_photo_download_url when photo has no _master_record."""
+        from unittest.mock import Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        # Photo without _master_record attribute
+        mock_photo = Mock(spec=["_service"])
+        result = _refresh_photo_download_url(mock_photo)
+        self.assertFalse(result)
+
+    def test_refresh_photo_download_url_missing_record_name(self):
+        """Test _refresh_photo_download_url when _master_record has no recordName."""
+        from unittest.mock import Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock()
+        mock_photo._master_record = {"recordType": "CPLMaster"}  # No recordName  # noqa: SLF001
+        result = _refresh_photo_download_url(mock_photo)
+        self.assertFalse(result)
+
+    def test_refresh_photo_download_url_missing_service(self):
+        """Test _refresh_photo_download_url when photo has no _service."""
+        from unittest.mock import Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock(spec=["_master_record"])
+        mock_photo._master_record = {"recordName": "test-123", "recordType": "CPLMaster"}  # noqa: SLF001
+        result = _refresh_photo_download_url(mock_photo)
+        self.assertFalse(result)
+
+    def test_refresh_photo_download_url_missing_service_attributes(self):
+        """Test _refresh_photo_download_url when service is missing required attributes."""
+        from unittest.mock import Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock()
+        mock_photo._master_record = {"recordName": "test-123", "recordType": "CPLMaster"}  # noqa: SLF001
+        # Service missing zone_id (not in spec)
+        mock_service = Mock(spec=["_service_endpoint", "session", "params"])
+        mock_service._service_endpoint = "https://cv.icloud.com"  # noqa: SLF001
+        mock_service.params = {"auth": "token"}  # noqa: SLF001
+        mock_photo._service = mock_service  # noqa: SLF001
+        result = _refresh_photo_download_url(mock_photo)
+        self.assertFalse(result)
+
+    def test_refresh_photo_download_url_api_failure(self):
+        """Test _refresh_photo_download_url when API call raises exception."""
+        from unittest.mock import Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock()
+        mock_photo._master_record = {"recordName": "test-123", "recordType": "CPLMaster"}  # noqa: SLF001
+
+        mock_service = Mock()
+        mock_service._service_endpoint = "https://cv.icloud.com"  # noqa: SLF001
+        mock_service.zone_id = {"zoneName": "PrimarySync"}  # noqa: SLF001
+        mock_service.params = {"auth": "token"}  # noqa: SLF001
+        mock_service.session.post.side_effect = ConnectionError("Network error")  # noqa: SLF001
+        mock_photo._service = mock_service  # noqa: SLF001
+
+        result = _refresh_photo_download_url(mock_photo)
+        self.assertFalse(result)
+
+    def test_refresh_photo_download_url_record_not_in_response(self):
+        """Test _refresh_photo_download_url when requested record is not in API response."""
+        from unittest.mock import MagicMock, Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock()
+        mock_photo._master_record = {"recordName": "test-123", "recordType": "CPLMaster"}  # noqa: SLF001
+
+        mock_service = Mock()
+        mock_service._service_endpoint = "https://cv.icloud.com"  # noqa: SLF001
+        mock_service.zone_id = {"zoneName": "PrimarySync"}  # noqa: SLF001
+        mock_service.params = {"auth": "token"}  # noqa: SLF001
+        mock_photo._service = mock_service  # noqa: SLF001
+
+        # API returns a different record
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "records": [{"recordName": "different-record", "recordType": "CPLMaster", "fields": {}}],
+        }
+        mock_service.session.post.return_value = mock_response
+
+        result = _refresh_photo_download_url(mock_photo)
+        self.assertFalse(result)
+
+    def test_refresh_photo_download_url_empty_records(self):
+        """Test _refresh_photo_download_url when API returns empty records list."""
+        from unittest.mock import MagicMock, Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock()
+        mock_photo._master_record = {"recordName": "test-123", "recordType": "CPLMaster"}  # noqa: SLF001
+
+        mock_service = Mock()
+        mock_service._service_endpoint = "https://cv.icloud.com"  # noqa: SLF001
+        mock_service.zone_id = {"zoneName": "PrimarySync"}  # noqa: SLF001
+        mock_service.params = {"auth": "token"}  # noqa: SLF001
+        mock_photo._service = mock_service  # noqa: SLF001
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"records": []}
+        mock_service.session.post.return_value = mock_response
+
+        result = _refresh_photo_download_url(mock_photo)
+        self.assertFalse(result)
+
+    @patch("src.photo_file_utils._refresh_photo_download_url")
+    def test_download_photo_from_server_410_calls_refresh(self, mock_refresh):
+        """Test that download_photo_from_server calls _refresh_photo_download_url on 410."""
+        import datetime
+        import tempfile
+        from io import BytesIO
+        from unittest.mock import MagicMock, Mock
+
+        from src.photo_file_utils import download_photo_from_server
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            destination_path = os.path.join(tmpdir, "test_photo.jpg")
+
+            mock_photo = Mock()
+            mock_photo._versions = {"original": {"url": "http://expired.url"}}  # noqa: SLF001
+
+            mock_response = MagicMock()
+            mock_response.raw = BytesIO(b"fake image data")
+
+            call_count = [0]
+
+            def download_side_effect(*args, **kwargs):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    raise Exception("Gone (410)")  # noqa: EM101
+                return mock_response
+
+            mock_photo.download.side_effect = download_side_effect
+            mock_photo.added_date = datetime.datetime(2021, 1, 1, 12, 0, 0)
+
+            # Make refresh return True (simulates successful refresh)
+            mock_refresh.return_value = True
+
+            result = download_photo_from_server(mock_photo, "original", destination_path)
+            self.assertTrue(result)
+            # Verify refresh was called on 410
+            mock_refresh.assert_called_once_with(mock_photo)
+
+    @patch("src.photo_file_utils._refresh_photo_download_url")
+    def test_download_photo_from_server_410_refresh_failure_still_retries(self, mock_refresh):
+        """Test that download retries even when _refresh_photo_download_url fails."""
+        import datetime
+        import tempfile
+        from io import BytesIO
+        from unittest.mock import MagicMock, Mock
+
+        from src.photo_file_utils import download_photo_from_server
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            destination_path = os.path.join(tmpdir, "test_photo.jpg")
+
+            mock_photo = Mock()
+            mock_photo._versions = {"original": {"url": "http://expired.url"}}  # noqa: SLF001
+
+            mock_response = MagicMock()
+            mock_response.raw = BytesIO(b"fake image data")
+
+            call_count = [0]
+
+            def download_side_effect(*args, **kwargs):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    raise Exception("Gone (410)")  # noqa: EM101
+                return mock_response
+
+            mock_photo.download.side_effect = download_side_effect
+            mock_photo.added_date = datetime.datetime(2021, 1, 1, 12, 0, 0)
+
+            # Make refresh return False (simulates refresh failure)
+            mock_refresh.return_value = False
+
+            result = download_photo_from_server(mock_photo, "original", destination_path)
+            # Should still succeed because download_photo_from_server retries regardless
+            self.assertTrue(result)
+            mock_refresh.assert_called_once_with(mock_photo)
+
     def test_generate_photo_path_different_normalization(self):
         """Test generate_photo_path with different normalization (line 107)."""
         from src.photo_download_manager import generate_photo_path


### PR DESCRIPTION
## Problem

The fix from PR #389 (closing #386) for HTTP 410 Gone errors during photo downloads has a **fundamental flaw in the URL refresh mechanism**. When a 410 error occurs, `photo._versions = None` forces icloudpy to re-parse the download URL from `photo._master_record`, but **`_master_record` itself is never refreshed from iCloud's servers**. The retry therefore requests the exact same expired URL and fails immediately every time.

This causes large Photo libraries (60K+ photos) to get stuck in a non-converging retry loop, generating 600K+ logged 410 errors across sync cycles with no improvement between runs.

### Root Cause Analysis

1. iCloud download URLs are signed CDN tokens with a ~30-40 minute TTL
2. Album enumeration fetches pages of 200 records, creating `PhotoAsset` objects with baked-in `downloadURL` values in `_master_record`
3. For large libraries, the download phase exceeds the URL TTL window — later photos have expired URLs by the time they are downloaded
4. The existing retry clears `_versions`, which forces icloudpy to re-parse `_master_record["fields"][...]["downloadURL"]` — but that record is stale and contains the same expired URL
5. Result: retry fails within milliseconds with the same 410, every time

## Fix

Add `_refresh_photo_download_url(photo)` which makes a new `records/query` API call to iCloud to obtain a **fresh master record with updated `downloadURL`** values, then updates `photo._master_record` in place and clears `_versions`.

### Changes

- **`src/photo_file_utils.py`**: Added `_refresh_photo_download_url()` function and `_DESIRED_KEYS` constant. Modified 410 retry path in `download_photo_from_server()` to call the refresh function instead of just clearing `_versions`.
- **`tests/test_sync_photos.py`**: Added 10 new tests covering success, missing attributes, API failures, record-not-found, and integration with the retry flow.

### Test Results

- 545 tests pass, 100% coverage
- Ruff lint clean

## Fixes #491
