### PR TITLE
docs: update documentation for v1.28.0 release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,7 @@ This is a containerized iCloud sync client that downloads files/photos from iClo
 - **`photo_filter_utils.py`**: Photo filtering by extensions and album preferences
 - **`photo_path_utils.py`**: Path normalization and folder format handling
 - **`photo_file_utils.py`**: File operations and metadata handling
+  - `_refresh_photo_download_url(photo)`: Re-fetches master record from iCloud on HTTP 410 Gone errors, obtaining fresh download URLs before retrying. Called during 410 retry path in `download_photo_from_server()`.
 - **`hardlink_registry.py`**: `HardlinkRegistry` class for deduplication across albums
 - **File sizes**: `original`, `original_alt` (RAW fallback), `medium`, `thumb`
 - **Hardlink deduplication**: `use_hardlinks` mode with registry tracking across albums

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ app:
     retry_login_interval: 600
   # Drive destination
   root: "/icloud"
+  # Optional: refuse to sync if a marker file is missing in the destination.
+  # Prevents writing into a wrong directory when bind-mounts fail silently.
+  # mount_marker_filename: ".mounted"
   discord:
   # webhook_url: <your server webhook URL here>
   # username: icloud-docker #or any other name you prefer
@@ -119,6 +122,8 @@ drive:
   # Remove local files that are not present on server (i.e. files delete on server)
   remove_obsolete: false
   sync_interval: 300
+  # Optional: refuse to sync if a marker file is missing in the destination.
+  # require_mount_marker: false
   filters: # Optional - use it only if you want to download specific folders.
     # File filters to be included in syncing iCloud drive content
     folders:
@@ -143,6 +148,9 @@ photos:
   all_albums: false # Optional, default false. If true preserve album structure. If same photo is in multiple albums creates duplicates on filesystem
   use_hardlinks: false # Optional, default false. If true and all_albums is true, create hard links for duplicate photos instead of separate copies. Saves storage space.
   folder_format: "%Y/%m" # optional, if set put photos in subfolders according to format. Format cheatsheet - https://strftime.org
+  # enumeration_chunk_size: 1000 # Optional, default 1000. Photos buffered per streaming chunk. Lower = lower peak memory on huge libraries, slightly more per-chunk overhead.
+  # Optional: refuse to sync if a marker file is missing in the destination.
+  # require_mount_marker: false
   filters:
     # List of libraries to download. If omitted (default), photos from all libraries (own and shared) are downloaded. If included, photos only
     # from the listed libraries are downloaded.
@@ -215,6 +223,30 @@ photos:
 **Storage Impact Example:**
 - **Without hard links**: Same photo in 3 albums = 3 separate files (3× storage usage)
 - **With hard links**: Same photo in 3 albums = 1 file + 2 hard links (1× storage usage)
+
+### Streaming Album Enumeration (Memory Optimization)
+
+For users with large photo libraries (100K+ photos), the sync process can consume significant memory during album enumeration. The streaming enumeration feature bounds peak memory usage by processing photos in fixed-size chunks instead of loading the entire album into memory at once.
+
+**How it works:**
+- Photos are processed in chunks (default: 1000 photos per chunk)
+- Each chunk is downloaded before the next chunk is loaded
+- Peak memory usage is bounded by chunk size, not total album size
+
+**Configuration:**
+```yaml
+photos:
+  enumeration_chunk_size: 1000  # Default: 1000. Lower values reduce peak memory.
+```
+
+**Performance Impact:**
+- **Large libraries (100K+ photos)**: Reduces peak memory from 4 GB+ to under 1 GB
+- **Small libraries**: Minimal impact, slight overhead from chunk boundaries
+- **Invalid values**: Non-positive or non-numeric values fall back to default (1000)
+
+**When to adjust:**
+- If your container has a low `mem_limit` (e.g., 2 GB), keep the default or lower it
+- If you have ample memory and want slightly fewer chunk boundaries, increase it
 
 ## Notifications
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,10 @@ app:
   # integer: specific number of threads (max 16)
   # max_threads: auto
   # max_threads: 4
+  # Optional: filename for the mount marker file (default: ".mounted")
+  # When require_mount_marker is enabled in drive or photos, sync refuses
+  # to proceed until this file exists in the destination directory.
+  # mount_marker_filename: ".mounted"
   notifications:
     # Sync summary notifications - sent after each sync cycle with statistics
     sync_summary:
@@ -60,6 +64,9 @@ drive:
   # HTTP read timeout in seconds for iCloud API requests (default: 30)
   # Prevents the sync process from hanging indefinitely on stalled connections
   # request_timeout: 30
+  # Optional: refuse to sync if a marker file is missing in the destination.
+  # Prevents writing into a wrong directory when bind-mounts fail silently.
+  # require_mount_marker: false
   filters:
     # File filters to be included in syncing iCloud drive content
     folders:
@@ -81,6 +88,8 @@ photos:
   use_hardlinks: false # Optional, default false. If true and all_albums is true, create hard links for duplicate photos instead of separate copies. Saves storage space.
   # folder_format: "%Y/%m" # optional, if set put photos in subfolders according to format. Format cheatsheet - https://strftime.org
   # enumeration_chunk_size: 1000 # optional, default 1000. Photos buffered per streaming chunk when downloading. Lower = lower peak memory on huge libraries, slightly more per-chunk overhead. Invalid/<=0 falls back to default.
+  # Optional: refuse to sync if a marker file is missing in the destination.
+  # require_mount_marker: false
   filters:
     # List of libraries to download. If omitted (default), photos from all libraries (own and shared) are downloaded. If included, photos only
     # from the listed libraries are downloaded.


### PR DESCRIPTION
## Summary

Updates project documentation to cover the three features shipping in v1.28.0:

1. **perf(photos)**: `photos.enumeration_chunk_size` — stream album enumeration in fixed-size chunks to bound peak RSS on large libraries ([#472](https://github.com/mandarons/icloud-docker/pull/472))
2. **feat**: `drive.require_mount_marker`, `photos.require_mount_marker`, `app.mount_marker_filename` — optional failsafe to refuse sync without a marker file ([#463](https://github.com/mandarons/icloud-docker/pull/463))
3. **fix(photos)**: `_refresh_photo_download_url` — re-fetch master record on 410 instead of clearing cached versions ([#492](https://github.com/mandarons/icloud-docker/pull/492))

## Changes

### README.md
- Added `photos.enumeration_chunk_size` to sample config (photos section)
- Added `drive.require_mount_marker` and `photos.require_mount_marker` to sample config
- Added `app.mount_marker_filename` to sample config (app section)
- Added new **Streaming Album Enumeration (Memory Optimization)** subsection under Performance Optimization

### config.yaml
- Added `app.mount_marker_filename` (commented out, with explanation)
- Added `drive.require_mount_marker` (commented out, with explanation)
- Added `photos.require_mount_marker` (commented out, with explanation)

### .github/copilot-instructions.md
- Documented `_refresh_photo_download_url()` in the Photos Sync Modules section

## Verification

- [x] `run-ci.sh` passes: ruff clean, 545 tests pass, 100% coverage maintained
