### PR TITLE
fix: preserve mount marker file during remove_obsolete cleanup

### DIFF
--- a/src/photo_cleanup_utils.py
+++ b/src/photo_cleanup_utils.py
@@ -13,12 +13,19 @@ from src import get_logger
 LOGGER = get_logger()
 
 
-def remove_obsolete_files(destination_path: str | None, tracked_files: set[str] | None) -> set[str]:
+def remove_obsolete_files(
+    destination_path: str | None,
+    tracked_files: set[str] | None,
+    exclude_filenames: set[str] | None = None,
+) -> set[str]:
     """Remove local obsolete files that are no longer on server.
 
     Args:
         destination_path: Path to search for obsolete files
         tracked_files: Set of files that should be kept (files on server)
+        exclude_filenames: Set of filenames (basename only) that must never
+            be removed even if they are not in ``tracked_files``.  Used to
+            protect the mount-marker sentinel file from cleanup.
 
     Returns:
         Set of paths that were removed
@@ -32,6 +39,8 @@ def remove_obsolete_files(destination_path: str | None, tracked_files: set[str] 
         local_file = str(path.absolute())
         if local_file not in tracked_files:
             if path.is_file():
+                if exclude_filenames and path.name in exclude_filenames:
+                    continue
                 LOGGER.info(f"Removing {local_file} ...")
                 path.unlink(missing_ok=True)
                 removed_paths.add(local_file)

--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -434,12 +434,14 @@ def sync_photos(config, photos):
     # configured we walk each library's subdir independently, otherwise the
     # legacy single-destination walk preserves backward compatibility.
     if config_parser.get_photos_remove_obsolete(config=config):
+        marker_filename = config_parser.get_mount_marker_filename(config=config)
+        exclude = {marker_filename}
         if library_destinations:
             for library in libraries:
                 lib_dest = _library_destination(destination_path, library, library_destinations)
-                remove_obsolete_files(lib_dest, files)
+                remove_obsolete_files(lib_dest, files, exclude_filenames=exclude)
         else:
-            remove_obsolete_files(destination_path, files)
+            remove_obsolete_files(destination_path, files, exclude_filenames=exclude)
 
     return total_successful, total_failed
 

--- a/tests/test_photo_cleanup_utils.py
+++ b/tests/test_photo_cleanup_utils.py
@@ -1,0 +1,110 @@
+"""Tests for photo_cleanup_utils.py module."""
+
+__author__ = "Mandar Patil (mandarons@pm.me)"
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from src import photo_cleanup_utils
+
+
+class TestRemoveObsoleteFiles(unittest.TestCase):
+    """Tests for remove_obsolete_files function."""
+
+    def setUp(self):
+        """Create a temporary directory with test files."""
+        self.temp_dir = tempfile.mkdtemp()
+        # Create some tracked files (simulating iCloud-synced photos)
+        self.tracked_files = set()
+        for name in ["photo1.jpg", "photo2.png", "subdir/photo3.jpg"]:
+            file_path = os.path.join(self.temp_dir, name)
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            with open(file_path, "w") as f:
+                f.write("content")
+            self.tracked_files.add(str(os.path.abspath(file_path)))
+
+    def tearDown(self):
+        """Remove temporary directory."""
+        shutil.rmtree(self.temp_dir)
+
+    def test_removes_untracked_files(self):
+        """Files not in tracked_files should be removed."""
+        # Create an untracked file
+        untracked = os.path.join(self.temp_dir, "old_photo.jpg")
+        with open(untracked, "w") as f:
+            f.write("old content")
+
+        removed = photo_cleanup_utils.remove_obsolete_files(self.temp_dir, self.tracked_files)
+        self.assertFalse(os.path.exists(untracked))
+        self.assertIn(str(os.path.abspath(untracked)), removed)
+
+    def test_preserves_tracked_files(self):
+        """Files in tracked_files should not be removed."""
+        removed = photo_cleanup_utils.remove_obsolete_files(self.temp_dir, self.tracked_files)
+        for f in self.tracked_files:
+            self.assertTrue(os.path.exists(f))
+        self.assertEqual(len(removed), 0)
+
+    def test_preserves_excluded_filenames(self):
+        """Files in exclude_filenames should not be removed even if untracked."""
+        marker = ".backup_sentinel"
+        marker_path = os.path.join(self.temp_dir, marker)
+        with open(marker_path, "w") as f:
+            f.write("sentinel")
+
+        untracked = os.path.join(self.temp_dir, "old_photo.jpg")
+        with open(untracked, "w") as f:
+            f.write("old content")
+
+        removed = photo_cleanup_utils.remove_obsolete_files(
+            self.temp_dir, self.tracked_files, exclude_filenames={marker},
+        )
+        # Marker should be preserved
+        self.assertTrue(os.path.exists(marker_path))
+        # Untracked file should be removed
+        self.assertFalse(os.path.exists(untracked))
+        self.assertIn(str(os.path.abspath(untracked)), removed)
+
+    def test_excludes_multiple_filenames(self):
+        """Multiple filenames in exclude_filenames should all be preserved."""
+        excluded = {".backup_sentinel", ".mounted"}
+        for name in excluded:
+            path = os.path.join(self.temp_dir, name)
+            with open(path, "w") as f:
+                f.write("sentinel")
+
+        untracked = os.path.join(self.temp_dir, "old_photo.jpg")
+        with open(untracked, "w") as f:
+            f.write("old content")
+
+        photo_cleanup_utils.remove_obsolete_files(
+            self.temp_dir, self.tracked_files, exclude_filenames=excluded,
+        )
+        for name in excluded:
+            self.assertTrue(os.path.exists(os.path.join(self.temp_dir, name)))
+        self.assertFalse(os.path.exists(untracked))
+
+    def test_excluded_filenames_not_required(self):
+        """Function works without exclude_filenames parameter (backward compat)."""
+        untracked = os.path.join(self.temp_dir, "old_photo.jpg")
+        with open(untracked, "w") as f:
+            f.write("old content")
+
+        photo_cleanup_utils.remove_obsolete_files(self.temp_dir, self.tracked_files)
+        self.assertFalse(os.path.exists(untracked))
+
+    def test_returns_empty_set_when_no_destination(self):
+        """Returns empty set when destination_path is None."""
+        result = photo_cleanup_utils.remove_obsolete_files(None, self.tracked_files)
+        self.assertEqual(result, set())
+
+    def test_returns_empty_set_when_no_files(self):
+        """Returns empty set when tracked_files is None."""
+        result = photo_cleanup_utils.remove_obsolete_files(self.temp_dir, None)
+        self.assertEqual(result, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -370,6 +370,38 @@ class TestSyncPhotos(unittest.TestCase):
 
         self.assertFalse(os.path.exists(os.path.join(album_1_path, "delete_me.JPG")))
 
+    @patch(target="keyring.get_password", return_value=data.VALID_PASSWORD)
+    @patch(target="src.config_parser.get_username", return_value=data.AUTHENTICATED_USER)
+    @patch("icloudpy.ICloudPyService")
+    @patch("src.read_config")
+    def test_sync_photos_remove_obsolete_preserves_mount_marker(
+        self,
+        mock_read_config,
+        mock_service,
+        mock_get_username,
+        mock_get_password,
+    ):
+        """Mount marker must survive remove_obsolete cleanup (issue #508)."""
+        mock_service = self.service
+        config = self.config.copy()
+        config["photos"]["destination"] = self.destination_path
+        config["photos"]["remove_obsolete"] = True
+        config.setdefault("app", {})["mount_marker_filename"] = ".backup_sentinel"
+        mock_read_config.return_value = config
+
+        # Create the mount marker file before sync
+        marker_path = os.path.join(self.destination_path, ".backup_sentinel")
+        with open(marker_path, "w") as f:
+            f.write("sentinel")
+
+        sync_photos.sync_photos(config=config, photos=mock_service.photos)
+
+        # Marker must still exist after sync with remove_obsolete
+        self.assertTrue(
+            os.path.exists(marker_path),
+            "Mount marker .backup_sentinel was deleted by remove_obsolete",
+        )
+
     def test_remove_obsolete_none_destination_path(self):
         """Test for destination path as None."""
         self.assertTrue(len(sync_photos.remove_obsolete(destination_path=None, files=set())) == 0)


### PR DESCRIPTION
## Problem

When `require_mount_marker` and `remove_obsolete` are both enabled for photos sync, the cleanup step deletes the custom mount marker file (e.g., `.backup_sentinel`) because it is not in the `tracked_files` set from iCloud. This causes every subsequent sync to refuse to start, since `_check_mount_marker()` finds the sentinel missing.

**Reproduction (from #508):**

```yaml
app:
    root: "/icloud"
    mount_marker_filename: ".backup_sentinel"
photos:
    destination: "icloud_docker"
    require_mount_marker: true
    remove_obsolete: true
```

After one successful sync, the marker is deleted and all future syncs fail.

## Fix

- Add an `exclude_filenames` parameter to `remove_obsolete_files()` in `src/photo_cleanup_utils.py`. Files whose basename is in this set are never removed, even if they are not in `tracked_files`.
- In `src/sync_photos.py`, resolve the mount marker filename via `config_parser.get_mount_marker_filename(config)` and pass it as an exclusion when calling `remove_obsolete_files()`.

## Tests

- 7 new unit tests in `tests/test_photo_cleanup_utils.py` covering the `exclude_filenames` parameter.
- 1 new integration test in `tests/test_sync_photos.py` (`test_sync_photos_remove_obsolete_preserves_mount_marker`) that creates a marker file, runs sync with `remove_obsolete: true`, and asserts the marker survives.

## Verification

- `ruff check` — clean
- `pytest` — **707 passed, 100% coverage**

Fixes #508
