### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,11 +795,11 @@ As mentioned in [USAGE.md](https://github.com/mandarons/icloud-docker/blob/main/
 
 ## Star History
 
-<a href="https://star-history.com/#mandarons/icloud-docker&Timeline">
+<a href="https://star-history.dera.page/#mandarons/icloud-docker&Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=mandarons/icloud-docker&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=mandarons/icloud-docker&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=mandarons/icloud-docker&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mandarons/icloud-docker&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mandarons/icloud-docker&type=Timeline" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mandarons/icloud-docker&type=Timeline" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart is currently broken because GitHub has restricted access to its stargazer API, so the graph no longer renders in the README. This change points the chart at a working data source to restore it.

No other changes are made.