### PR TITLE
fix(photos): use records/lookup to refresh expired download URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Expired download URL (HTTP 410) recovery now uses CloudKit `records/lookup` instead
+  of `records/query`. `CPLMaster` is not a query-indexable type, so every refresh
+  attempt failed with `Type is not marked indexable: CPLMaster (BAD_REQUEST)`, which
+  could stop large albums syncing entirely ([#521](https://github.com/mandarons/icloud-docker/issues/521))
+
+### Changed
+
+- Repeated consecutive download URL refresh failures are logged at WARNING rather than
+  only DEBUG, so a systematically broken refresh path is visible by default
+
 ## [1.28.0] - 2026-07-27
 
 ### Added

--- a/docs/systems/photos-sync.md
+++ b/docs/systems/photos-sync.md
@@ -57,6 +57,11 @@ Photos sync is purely a download system. It writes to the local filesystem at th
 - `folder_format` uses strftime patterns (e.g., `"%Y/%m"`)
 - `enumeration_chunk_size` bounds peak memory (default 1000 photos/chunk)
 - HTTP 410 Gone triggers download URL refresh via `_refresh_photo_download_url()`
+- URL refresh MUST use CloudKit `records/lookup`, not `records/query` — `CPLMaster`
+  is not a query-indexable type and querying it always fails with
+  `Type is not marked indexable: CPLMaster (BAD_REQUEST)`
+- Repeated consecutive refresh failures escalate from DEBUG to WARNING, so a
+  systematically broken refresh path is visible without debug logging
 
 ## Dependencies
 

--- a/src/photo_file_utils.py
+++ b/src/photo_file_utils.py
@@ -20,6 +20,12 @@ LOGGER = get_logger()
 # Module-level lock to protect thread-safe mutation of photo._versions during retries
 _versions_refresh_lock = threading.Lock()
 
+# Consecutive download-URL refresh failures, and how often to escalate them to WARNING.
+# Downloads run in parallel, so the counter is guarded by its own lock.
+_refresh_failure_lock = threading.Lock()
+_consecutive_refresh_failures = 0
+_REFRESH_FAILURE_WARN_INTERVAL = 3
+
 # CloudKit fields to request when re-fetching a photo record for fresh download URLs.
 # Mirrors the desiredKeys list used by icloudpy's PhotoAlbum._list_query_gen().
 _DESIRED_KEYS = [
@@ -127,6 +133,40 @@ _DESIRED_KEYS = [
 ]
 
 
+def _note_refresh_success() -> None:
+    """Reset the consecutive refresh-failure streak after a successful refresh."""
+    global _consecutive_refresh_failures  # noqa: PLW0603
+    with _refresh_failure_lock:
+        _consecutive_refresh_failures = 0
+
+
+def _note_refresh_failure(record_name: str, reason: str) -> None:
+    """Record a failed URL refresh, escalating to WARNING once failures repeat.
+
+    URL refresh is the last line of defence before a download is abandoned, so a
+    systematically broken refresh path (rather than an occasional miss) should be
+    visible without turning on debug logging.  Individual failures stay at DEBUG;
+    every ``_REFRESH_FAILURE_WARN_INTERVAL`` consecutive failures emits a WARNING.
+
+    Args:
+        record_name: CloudKit recordName of the photo being refreshed
+        reason: Human-readable description of why the refresh failed
+    """
+    global _consecutive_refresh_failures  # noqa: PLW0603
+    with _refresh_failure_lock:
+        _consecutive_refresh_failures += 1
+        failures = _consecutive_refresh_failures
+
+    if failures % _REFRESH_FAILURE_WARN_INTERVAL == 0:
+        LOGGER.warning(
+            f"Download URL refresh has failed {failures} times in a row - expired-URL (HTTP 410) "
+            f"recovery is not working, so affected photos will be reported as failed downloads. "
+            f"Most recent failure: {record_name} - {reason}",
+        )
+    else:
+        LOGGER.debug(f"Failed to refresh download URL for {record_name}: {reason}")
+
+
 def _refresh_photo_download_url(photo) -> bool:
     """Re-fetch the photo's master record from iCloud to obtain fresh download URLs.
 
@@ -134,9 +174,14 @@ def _refresh_photo_download_url(photo) -> bool:
     When a URL expires (HTTP 410 Gone), clearing ``photo._versions`` alone is
     insufficient because icloudpy re-parses the same stale ``_master_record``
     which still contains the expired URL.  This function makes a new
-    ``records/query`` API call to get an updated master record with fresh URLs,
+    ``records/lookup`` API call to get an updated master record with fresh URLs,
     then updates ``photo._master_record`` in place and clears ``_versions`` so
     the next ``download()`` call uses the fresh URL.
+
+    ``records/lookup`` is used rather than ``records/query`` because ``CPLMaster``
+    is not a query-indexable CloudKit type: querying it fails every time with
+    ``Type is not marked indexable: CPLMaster (BAD_REQUEST)``.  Lookup fetches
+    records by name and returns the same ``{"records": [...]}`` shape.
 
     Args:
         photo: PhotoAsset object from icloudpy
@@ -146,14 +191,13 @@ def _refresh_photo_download_url(photo) -> bool:
     """
     try:
         record_name = photo._master_record["recordName"]  # noqa: SLF001
-        record_type = photo._master_record.get("recordType", "CPLMaster")  # noqa: SLF001
     except (AttributeError, KeyError, TypeError):
-        LOGGER.debug("Cannot refresh download URL: photo missing _master_record or recordName")
+        _note_refresh_failure("<unknown>", "photo missing _master_record or recordName")
         return False
 
     service = getattr(photo, "_service", None)
     if service is None:
-        LOGGER.debug("Cannot refresh download URL: photo missing _service")
+        _note_refresh_failure(record_name, "photo missing _service")
         return False
 
     endpoint = getattr(service, "_service_endpoint", None)
@@ -162,26 +206,13 @@ def _refresh_photo_download_url(photo) -> bool:
     zone_id = getattr(service, "zone_id", None)
 
     if not all([endpoint, session, params, zone_id]):
-        LOGGER.debug("Cannot refresh download URL: photo._service missing required attributes")
+        _note_refresh_failure(record_name, "photo._service missing required attributes")
         return False
 
     try:
-        url = f"{endpoint}/records/query?{urlencode(params)}"
+        url = f"{endpoint}/records/lookup?{urlencode(params)}"
         query = {
-            "query": {
-                "recordType": record_type,
-                "filterBy": [
-                    {
-                        "fieldName": "recordName",
-                        "comparator": "IN",
-                        "fieldValue": {
-                            "type": "STRING_LIST",
-                            "value": [record_name],
-                        },
-                    },
-                ],
-            },
-            "resultsLimit": 1,
+            "records": [{"recordName": record_name}],
             "desiredKeys": _DESIRED_KEYS,
             "zoneID": zone_id,
         }
@@ -199,13 +230,14 @@ def _refresh_photo_download_url(photo) -> bool:
                 with _versions_refresh_lock:
                     photo._versions = None  # noqa: SLF001
                 LOGGER.debug(f"Refreshed download URL for {record_name}")
+                _note_refresh_success()
                 return True
 
-        LOGGER.debug(f"Record {record_name} not found in iCloud response during URL refresh")
+        _note_refresh_failure(record_name, "record not found in iCloud response")
         return False
 
     except Exception as e:  # noqa: BLE001
-        LOGGER.debug(f"Failed to refresh download URL for {record_name}: {e!s}")
+        _note_refresh_failure(record_name, str(e))
         return False
 
 

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -2203,6 +2203,94 @@ class TestSyncPhotos(unittest.TestCase):
         result = _refresh_photo_download_url(mock_photo)
         self.assertFalse(result)
 
+    def test_refresh_photo_download_url_uses_records_lookup(self):
+        """Test _refresh_photo_download_url calls records/lookup, not records/query.
+
+        CPLMaster is not a query-indexable CloudKit type, so records/query fails
+        every time with "Type is not marked indexable: CPLMaster (BAD_REQUEST)".
+        """
+        import json
+        from unittest.mock import MagicMock, Mock
+
+        from src.photo_file_utils import _refresh_photo_download_url
+
+        mock_photo = Mock()
+        mock_photo._master_record = {"recordName": "test-123", "recordType": "CPLMaster"}  # noqa: SLF001
+
+        mock_service = Mock()
+        mock_service._service_endpoint = "https://cv.icloud.com"  # noqa: SLF001
+        mock_service.zone_id = {"zoneName": "PrimarySync"}  # noqa: SLF001
+        mock_service.params = {"auth": "token"}  # noqa: SLF001
+        mock_photo._service = mock_service  # noqa: SLF001
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"records": [{"recordName": "test-123"}]}
+        mock_service.session.post.return_value = mock_response
+
+        self.assertTrue(_refresh_photo_download_url(mock_photo))
+
+        called_url = mock_service.session.post.call_args[0][0]
+        self.assertIn("/records/lookup?", called_url)
+        self.assertNotIn("/records/query", called_url)
+
+        body = json.loads(mock_service.session.post.call_args[1]["data"])
+        self.assertEqual(body["records"], [{"recordName": "test-123"}])
+        self.assertNotIn("query", body)
+        self.assertEqual(body["zoneID"], {"zoneName": "PrimarySync"})
+
+    def test_refresh_failure_streak_escalates_to_warning(self):
+        """Test repeated refresh failures escalate from DEBUG to WARNING."""
+        from unittest.mock import Mock, patch
+
+        from src import photo_file_utils
+
+        mock_photo = Mock(spec=["_service"])
+
+        with (
+            patch.object(photo_file_utils, "_consecutive_refresh_failures", 0),
+            patch.object(photo_file_utils.LOGGER, "warning") as mock_warning,
+        ):
+            for _ in range(photo_file_utils._REFRESH_FAILURE_WARN_INTERVAL - 1):  # noqa: SLF001
+                self.assertFalse(photo_file_utils._refresh_photo_download_url(mock_photo))  # noqa: SLF001
+            mock_warning.assert_not_called()
+
+            # The Nth consecutive failure escalates
+            self.assertFalse(photo_file_utils._refresh_photo_download_url(mock_photo))  # noqa: SLF001
+            mock_warning.assert_called_once()
+            self.assertIn("failed", mock_warning.call_args[0][0])
+
+    def test_refresh_success_resets_failure_streak(self):
+        """Test a successful refresh clears the consecutive-failure counter."""
+        from unittest.mock import MagicMock, Mock, patch
+
+        from src import photo_file_utils
+
+        failing_photo = Mock(spec=["_service"])
+
+        mock_photo = Mock()
+        mock_photo._master_record = {"recordName": "test-123"}  # noqa: SLF001
+        mock_service = Mock()
+        mock_service._service_endpoint = "https://cv.icloud.com"  # noqa: SLF001
+        mock_service.zone_id = {"zoneName": "PrimarySync"}  # noqa: SLF001
+        mock_service.params = {"auth": "token"}  # noqa: SLF001
+        mock_photo._service = mock_service  # noqa: SLF001
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"records": [{"recordName": "test-123"}]}
+        mock_service.session.post.return_value = mock_response
+
+        with (
+            patch.object(photo_file_utils, "_consecutive_refresh_failures", 0),
+            patch.object(photo_file_utils.LOGGER, "warning") as mock_warning,
+        ):
+            for _ in range(photo_file_utils._REFRESH_FAILURE_WARN_INTERVAL - 1):  # noqa: SLF001
+                photo_file_utils._refresh_photo_download_url(failing_photo)  # noqa: SLF001
+
+            self.assertTrue(photo_file_utils._refresh_photo_download_url(mock_photo))  # noqa: SLF001
+
+            # Streak reset, so the next failure must not trip the warning
+            self.assertFalse(photo_file_utils._refresh_photo_download_url(failing_photo))  # noqa: SLF001
+            mock_warning.assert_not_called()
+
     @patch("src.photo_file_utils._refresh_photo_download_url")
     def test_download_photo_from_server_410_calls_refresh(self, mock_refresh):
         """Test that download_photo_from_server calls _refresh_photo_download_url on 410."""


### PR DESCRIPTION
Fixes #521.

## 1. `records/query` → `records/lookup`

`_refresh_photo_download_url()` re-fetched the master record with a CloudKit
`records/query` on record type `CPLMaster`. That type is not query-indexable, so
Apple rejects every such request:

```
Type is not marked indexable: CPLMaster (BAD_REQUEST)
```

The exception is swallowed by the trailing `except Exception` (logged at DEBUG), so
the HTTP 410 recovery path could never succeed — the only visible symptom was a
growing count of failed downloads.

`records/lookup` fetches records by name and returns the same `{"records": [...]}`
shape, so only the URL and the request body change; the response parsing is
untouched. `record_type` is no longer read, so that line is removed.

Verified against a live account (details and the paired `records/query` /
`records/lookup` transcript are in #521), then run in production for a full sync
cycle on a ~65,000-photo library:

```
before   Photo processing complete:   0 successful, 155 failed   (every run, 3 days)
after    Photo processing complete: 157 successful,   0 failed
"not marked indexable" occurrences since: 0
```

410s still occur — the enumeration window is unchanged — but they are now recovered
instead of fatal.

## 2. Repeated refresh failures escalate to WARNING

The secondary suggestion from the issue. URL refresh is the last line of defence
before a download is abandoned, so a *systematically* broken refresh path should be
visible without turning on debug logging — that is what kept this bug invisible.

Individual failures stay at DEBUG. Every third **consecutive** failure emits a
WARNING, and any success resets the streak, so an occasional miss stays quiet while a
broken path surfaces immediately:

```
DEBUG    Failed to refresh download URL for <record>: ...
DEBUG    Failed to refresh download URL for <record>: ...
WARNING  Download URL refresh has failed 3 times in a row - expired-URL (HTTP 410)
         recovery is not working, so affected photos will be reported as failed
         downloads. Most recent failure: <record> - ...
```

All five failure returns route through the counter, so it means "refresh did not
work" regardless of cause. Downloads run in parallel, so the counter has its own
lock.

## Tests

Three added to `tests/test_sync_photos.py`:

- `test_refresh_photo_download_url_uses_records_lookup` — asserts the request goes to
  `/records/lookup`, that the body carries `records: [{"recordName": ...}]`, and that
  no `query` key is present. This is the regression guard for #521.
- `test_refresh_failure_streak_escalates_to_warning`
- `test_refresh_success_resets_failure_streak`

`ruff check` clean; full suite passes with coverage at 100.00% against the enforced
`--cov-fail-under=100`.

I did not run `ruff format`: it wants to reformat 23 files on unmodified `main` as
well, and `run-ci.sh` only runs `ruff check --fix`. `src/photo_file_utils.py` is
already format-clean. Happy to include a formatting pass if you would rather have it,
but it seemed better kept out of this diff.

## Docs

- `CHANGELOG.md` — entry under `[Unreleased]`
- `docs/systems/photos-sync.md` — two invariants recording *why* lookup rather than
  query, so it does not get "simplified" back

## Not included

The issue's other secondary suggestion — a time-based flush in
`_collect_and_execute_album_in_chunks()`, draining on buffered-task age as well as
buffer size — is the deeper fix, since the 410 path only exists because URLs go stale
during a long enumeration. It is a real behaviour change and independent of this one,
so I have left it out. Happy to open it separately if you want it.

---

*Investigation done with Claude (Claude Code) — log analysis, code reading, and the
initial diagnosis. Every claim above was then verified by hand against the live API
and a production sync run; the before/after numbers and the `records/query` vs
`records/lookup` results are observed output, not model-generated.*
