### PR TITLE
fix(drive): stop re-downloading every package on every sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Drive packages (`.key`, `.pxm`, `.band`, `.framework`, `.app`, …) are no longer
+  re-downloaded on every sync. `package_exists()` compared the summed size of the
+  *unpacked* directory against `item.size`, which is the size of the remote *zip* —
+  never equal, so the up-to-date branch was unreachable
+  ([#525](https://github.com/mandarons/icloud-docker/issues/525))
+- Package extraction is gated on `zipfile.is_zipfile()` rather than the libmagic MIME
+  string, which reports `application/octet-stream` for many of Apple's packageDownload
+  zips. Previously those packages were never unpacked and the raw zip was left on disk
+  under the package's own name ([#525](https://github.com/mandarons/icloud-docker/issues/525))
+
 - Expired download URL (HTTP 410) recovery now uses CloudKit `records/lookup` instead
   of `records/query`. `CPLMaster` is not a query-indexable type, so every refresh
   attempt failed with `Type is not marked indexable: CPLMaster (BAD_REQUEST)`, which

--- a/docs/systems/drive-sync.md
+++ b/docs/systems/drive-sync.md
@@ -44,7 +44,13 @@ Drive sync is purely a download system — it does NOT upload files to iCloud. I
 
 - All file paths MUST be NFC-normalized with `unicodedata.normalize("NFC", path)`
 - Files are downloaded to temp paths, then moved atomically to final location
-- ZIP packages are auto-extracted when detected via `python-magic`
+- ZIP packages are auto-extracted when `zipfile.is_zipfile()` accepts them; `python-magic`
+  is consulted only for the gzip branch. Do not gate ZIP handling on the libmagic MIME
+  string — it reports `application/octet-stream` for many of Apple's packageDownload
+  zips, and a failed unpack leaves the raw archive on disk under the package's name
+- Package freshness is decided by `date_modified` **only**. `item.size` is the size of
+  the remote zip while the local package is an unpacked directory, so the two are never
+  comparable
 - Thread count is capped at `min(CPU_COUNT, 8)`, max 16
 - `files_lock` protects shared `files` set in parallel workers
 

--- a/src/drive_file_existence.py
+++ b/src/drive_file_existence.py
@@ -8,7 +8,6 @@ __author__ = "Mandar Patil (mandarons@pm.me)"
 
 import os
 from datetime import timezone
-from pathlib import Path
 from shutil import rmtree
 from typing import Any
 
@@ -75,17 +74,20 @@ def package_exists(item: Any, local_package_path: str) -> bool:
     # iCloudPy produces date_modified via strptime(..., "%Y-%m-%dT%H:%M:%SZ") — always
     # naive UTC with no tzinfo. replace(tzinfo=UTC) is the correct conversion.
     remote_package_modified_time = int(item.date_modified.replace(tzinfo=timezone.utc).timestamp())
-    local_package_size = sum(f.stat().st_size for f in Path(local_package_path).glob("**/*") if f.is_file())
-    remote_package_size = item.size
 
-    if local_package_modified_time == remote_package_modified_time and local_package_size == remote_package_size:
+    # Only date_modified is comparable here. A package is stored remotely as a zip and
+    # unpacked locally, so item.size (the zip) and the summed size of the unpacked
+    # directory are never equal — e.g. one .pxm is 7,821,180 bytes zipped and
+    # 11,716,516 unpacked. Requiring size equality made this branch unreachable, so
+    # every package was rmtree'd and re-downloaded on every single sync.
+    if local_package_modified_time == remote_package_modified_time:
         LOGGER.debug(f"No changes detected. Skipping the package {local_package_path} ...")
         return True
 
     LOGGER.info(
         f"Changes detected: local_modified_time is {local_package_modified_time}, "
-        + f"remote_modified_time is {remote_package_modified_time}, "
-        + f"local_package_size is {local_package_size} and remote_package_size is {remote_package_size}.",
+        + f"remote_modified_time is {remote_package_modified_time} "
+        + f"for package {local_package_path}.",
     )
     rmtree(local_package_path)
     return False

--- a/src/drive_package_processing.py
+++ b/src/drive_package_processing.py
@@ -36,16 +36,24 @@ def process_package(local_file: str) -> str | None:
         Path to the processed file/directory, or False if processing failed
     """
     archive_file = local_file
+
+    # zipfile.is_zipfile() rather than libmagic's MIME string: libmagic reports
+    # "application/octet-stream" for many of Apple's packageDownload zips even though
+    # they begin with PK\x03\x04 and open fine with zipfile. is_zipfile() reads the End
+    # of Central Directory record and is the authority on whether ZipFile() will
+    # succeed, which is all _process_zip_package() needs to know.
+    if zipfile.is_zipfile(local_file):
+        return _process_zip_package(local_file, archive_file)
+
     magic_object = magic.Magic(mime=True)
     file_mime_type = magic_object.from_file(filename=local_file)
 
-    if file_mime_type == "application/zip":
-        return _process_zip_package(local_file, archive_file)
-    elif file_mime_type == "application/gzip":
+    if file_mime_type == "application/gzip":
         return _process_gzip_package(local_file, archive_file)
     else:
         LOGGER.error(
-            f"Unhandled file type - cannot unpack the package {file_mime_type}.",
+            f"Unhandled file type - cannot unpack the package {local_file} ({file_mime_type}). "
+            "The downloaded archive is left in place under the package's name.",
         )
         return None
 

--- a/tests/test_sync_drive.py
+++ b/tests/test_sync_drive.py
@@ -1258,6 +1258,51 @@ class TestSyncDrive(unittest.TestCase):
         """Test for invalid package type."""
         self.assertFalse(sync_drive.process_package(local_file=os.path.join(DATA_DIR, "medium.jpeg")))
 
+    def test_package_exists_ignores_zip_versus_unpacked_size_mismatch(self):
+        """Package size is not comparable: item.size is the zip, local is the unpacked tree.
+
+        Requiring equality made the up-to-date branch unreachable for every real
+        package, so each one was rmtree'd and re-downloaded on every sync.
+        """
+        sync_drive.download_file(item=self.package_item, local_file=self.local_package_path)
+        self.assertTrue(os.path.isdir(self.local_package_path))
+
+        unpacked_size = sum(
+            f.stat().st_size for f in Path(self.local_package_path).glob("**/*") if f.is_file()
+        )
+        # Stand in for the remote zip's size, which is always smaller than the
+        # unpacked tree (Project.band.zip: 199,960 zipped -> 588,272 unpacked).
+        item = MagicMock()
+        item.date_modified = self.package_item.date_modified
+        item.size = unpacked_size // 2
+        self.assertNotEqual(item.size, unpacked_size)
+
+        self.assertTrue(
+            sync_drive.package_exists(item=item, local_package_path=self.local_package_path),
+        )
+        # And it must not have been deleted on the way to that answer
+        self.assertTrue(os.path.isdir(self.local_package_path))
+
+    def test_process_package_unpacks_zip_when_libmagic_reports_octet_stream(self):
+        """libmagic misidentifies many of Apple's packageDownload zips.
+
+        It returns application/octet-stream for files that begin with PK\\x03\\x04 and
+        open fine with zipfile. Gating on the MIME string meant process_package()
+        returned None and download_file() left the raw zip on disk under the
+        package's own name, so the package was never correctly mirrored.
+        """
+        local_file = os.path.join(self.destination_path, "Project.band")
+        shutil.copyfile(os.path.join(DATA_DIR, "Project.band.zip"), local_file)
+        self.assertTrue(os.path.isfile(local_file))
+
+        with patch("src.drive_package_processing.magic.Magic") as mock_magic:
+            mock_magic.return_value.from_file.return_value = "application/octet-stream"
+            result = sync_drive.process_package(local_file=local_file)
+
+        self.assertTrue(result)
+        self.assertTrue(os.path.isdir(local_file))
+        self.assertFalse(os.path.exists(local_file + ".zip"))
+
     def test_execution_continuation_on_icloudpy_exception(self):
         """Test for icloudpy exception."""
         with (


### PR DESCRIPTION
Fixes #525.

Two independent bugs meant every iCloud Drive package was re-downloaded on every
sync, forever. On my library that was **37 packages / 4.42 GB per pass**, with
`Bolts.framework` downloaded 276 times.

## 1. `package_exists()` compared the unpacked size against the zip size

```python
local_package_size = sum(f.stat().st_size for f in Path(local_package_path).glob("**/*") if f.is_file())
remote_package_size = item.size

if local_package_modified_time == remote_package_modified_time and local_package_size == remote_package_size:
```

`local_package_size` is the summed size of the **unpacked directory**; `item.size` is
the size of the **zip** that `/packageDownload?` serves. Never equal — the repo's own
fixture makes the point:

```
Project.band.zip:  199,960 bytes zipped  ->  588,272 bytes unpacked
```

So the up-to-date branch was unreachable, the directory was `rmtree`'d, and the
package re-downloaded. Production logs show the mtimes matching exactly and only the
size term failing:

```
Changes detected: local_modified_time is 1516900149, remote_modified_time is 1516900149,
local_package_size is 2715591 and remote_package_size is 2715550
```

**Fix:** compare `date_modified` only. There is no locally available quantity
comparable to `item.size` once a package is unpacked, and mtime is already the change
signal used for regular files.

## 2. `process_package()` gated extraction on libmagic

libmagic returns `application/octet-stream` for many of Apple's packageDownload zips,
even though they start with `PK\x03\x04` and open fine with `zipfile`:

```python
>>> magic.Magic(mime=True).from_file("Keynote/Migas.key")
'application/octet-stream'
>>> zipfile.is_zipfile("Keynote/Migas.key")
True
>>> zipfile.ZipFile("Keynote/Migas.key").namelist()[:2]
['Migas.key/', 'Migas.key/Data/']
```

**This is worse than a failed unpack.** `download_file()` writes the archive to the
package's *own path* before calling `process_package()`, so returning `None` leaves a
raw zip on disk wearing the package's name — a 96 MB file called `Migas.key` that is a
zip, not a Keynote bundle. The next pass sees a *file* rather than a directory, takes
the `os.path.isfile()` branch in `collect_file_for_download()`, compares the zip's size
against `item.size`, and re-downloads. 29 of my 37 packages were in this state and had
never been correctly mirrored.

**Fix:** gate on `zipfile.is_zipfile()`, which reads the End of Central Directory
record and is the authority on whether `ZipFile()` will succeed — the only thing
`_process_zip_package()` needs to know. libmagic still handles the gzip branch, so the
existing `ms.band.zip` (gzip, not a zip) fixture still routes correctly.

I also added the file path to the "Unhandled file type" error, since it was previously
impossible to tell *which* package failed, and noted in the message that the archive is
left in place.

## Tests

Two regression tests in `tests/test_sync_drive.py`. Both **fail on the current tree**
and pass with these changes — verified by stashing the `src/` changes and re-running:

```
FAILED test_package_exists_ignores_zip_versus_unpacked_size_mismatch
FAILED test_process_package_unpacks_zip_when_libmagic_reports_octet_stream
ERROR  root:drive_package_processing.py:47 Unhandled file type - cannot unpack the package application/octet-stream.
```

Worth noting **why the existing suite missed both**: the package fixtures are exercised
through `download_file()`, which unpacks and then sets the directory mtime, and the
mocked `item.size` lines up with what the assertions expect — so the zip-vs-unpacked
mismatch that every real package exhibits never arises. The new size test builds that
mismatch explicitly.

`ruff check` clean; full suite passes with coverage at 100.00% against the enforced
`--cov-fail-under=100`.

## Verification

Both fixes have been running here since 2026-08-20, bind-mounted over the v2.0.0 image.

Before, measured across ~70 passes of the persistent `icloud.log` since 2026-02-03:

```
37 packages re-downloaded on every pass          4.42 GB per pass
Bolts.framework                                  276 downloads
29 of the 37 stored on disk as raw zips, never unpacked
```

After, the first full pass to complete since April
(2026-08-20 15:33 → 2026-08-21 02:58):

```
packages unpacked OK : 112
unpack failures      : 0
duplicate downloads  : 0
```

```
$ file -b "Keynote/Migas.key"
before: Zip archive data, at least v2.0 to extract
after:  directory
```

Same for `Pixelmator/Image 2.pxm`, a 3.3 GB `.imovielibrary`, and
`Learn to Code 1.playgroundbook`.

## Not included: #527

A third, related bug lives in the same area and is filed separately as #527:
`download_file_task()` renames a package's children to NFD form *after*
`download_file()` has set the package directory's mtime, and for non-ASCII paths that
rename updates the parent directory's mtime to now — so `package_exists()` still fails
on mtime even after this PR. (For ASCII paths `os.rename(f, f)` is a POSIX no-op, which
is why it only affects some packages.)

I have left it out because I cannot verify it: the only non-ASCII package on my system
is 0 bytes, so I can see the mtime drift in the logs but cannot demonstrate a fix
end to end. Happy to add it with a constructed test case, here or in its own PR.

---

*Investigation done with Claude (Claude Code) — log analysis, code reading, and the
initial diagnosis. Every claim above was then verified by hand against the running
container and a full production sync pass; the byte counts, download tallies and
`file`/`magic`/`zipfile` outputs are observed output, not model-generated.*
