### PR TITLE
fix: rotate the log file instead of growing without bound

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,12 @@ app:
     level: "info"
     # log filename icloud.log
     filename: "/config/icloud.log"
+    # Rotate the log file rather than letting it grow without bound. One
+    # line is written per file considered each cycle, so a large library
+    # can reach several GB. Defaults: 50 MB per file, 3 backups. Set
+    # max_bytes to 0 if an external logrotate manages the file instead.
+    # max_bytes: 52428800
+    # backup_count: 3
   credentials:
     # iCloud drive username
     username: "please@replace.me"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 import warnings
+from logging.handlers import RotatingFileHandler
 
 from ruamel.yaml import YAML
 
@@ -21,6 +22,12 @@ ENV_ICLOUD_PASSWORD_KEY = "ENV_ICLOUD_PASSWORD"
 ENV_CONFIG_FILE_PATH_KEY = "ENV_CONFIG_FILE_PATH"
 DEFAULT_LOGGER_LEVEL = "info"
 DEFAULT_LOG_FILE_NAME = "icloud.log"
+# Rotation bounds for the file handler. A busy library logs one line per
+# file *considered* each cycle, so an unbounded handler grows without
+# limit -- multi-GB logs on large accounts. 50 MB x 3 backups keeps a
+# useful window at a bounded 200 MB worst case.
+DEFAULT_LOG_MAX_BYTES = 50 * 1024 * 1024
+DEFAULT_LOG_BACKUP_COUNT = 3
 DEFAULT_CONFIG_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), DEFAULT_CONFIG_FILE_NAME)
 # Operator-overridable via ICLOUD_DOCKER_CONFIG_DIR. Default ``/config`` is the
 # in-container mount point users bind their config volume to. The override
@@ -57,6 +64,8 @@ def get_logger_config(config):
     logger_config["filename"] = (
         config_app_logger["filename"].strip().lower() if "filename" in config_app_logger else DEFAULT_LOG_FILE_NAME
     )
+    logger_config["max_bytes"] = int(config_app_logger.get("max_bytes", DEFAULT_LOG_MAX_BYTES))
+    logger_config["backup_count"] = int(config_app_logger.get("backup_count", DEFAULT_LOG_BACKUP_COUNT))
     return logger_config
 
 
@@ -140,7 +149,14 @@ def get_logger():
             handler_type=logging.FileHandler,
             filename=logger_config["filename"],
         ):
-            file_handler = logging.FileHandler(logger_config["filename"])
+            # Rotating rather than plain FileHandler: see
+            # DEFAULT_LOG_MAX_BYTES. max_bytes=0 disables rotation for
+            # operators who hand the file to an external logrotate.
+            file_handler = RotatingFileHandler(
+                logger_config["filename"],
+                maxBytes=logger_config["max_bytes"],
+                backupCount=logger_config["backup_count"],
+            )
             file_handler.setFormatter(
                 logging.Formatter(
                     "%(asctime)s :: %(levelname)s :: %(name)s :: %(filename)s :: %(lineno)d :: %(message)s",

--- a/tests/test_src_init.py
+++ b/tests/test_src_init.py
@@ -6,6 +6,7 @@ import logging
 import unittest
 from unittest.mock import patch
 
+import src
 import tests
 from src import get_logger, read_config
 
@@ -47,3 +48,60 @@ class TestSrcInit(unittest.TestCase):
         number_of_handlers = len(logger.handlers)
         logger = get_logger()
         self.assertEqual(len(logger.handlers), number_of_handlers)
+
+
+class TestLogRotation(unittest.TestCase):
+    """The file handler rotates.
+
+    One line is logged per file *considered* each cycle, so a large
+    library grows the log without bound -- a real install reached 5.8 GB
+    with no rotation anywhere in the codebase."""
+
+    def test_defaults_are_bounded(self):
+        config = {"app": {"logger": {"level": "info", "filename": "icloud.log"}}}
+        logger_config = src.get_logger_config(config=config)
+        self.assertEqual(logger_config["max_bytes"], src.DEFAULT_LOG_MAX_BYTES)
+        self.assertEqual(logger_config["backup_count"], src.DEFAULT_LOG_BACKUP_COUNT)
+
+    def test_bounds_are_configurable(self):
+        config = {
+            "app": {
+                "logger": {
+                    "level": "info",
+                    "filename": "icloud.log",
+                    "max_bytes": 1024,
+                    "backup_count": 1,
+                },
+            },
+        }
+        logger_config = src.get_logger_config(config=config)
+        self.assertEqual(logger_config["max_bytes"], 1024)
+        self.assertEqual(logger_config["backup_count"], 1)
+
+    def test_handler_is_a_rotating_one(self):
+        import logging
+        from logging.handlers import RotatingFileHandler
+
+        # get_logger reuses handlers already attached, so an earlier test
+        # leaving a plain FileHandler in place would mask the change.
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        for handler in saved:
+            root.removeHandler(handler)
+        self.addCleanup(lambda: [root.addHandler(h) for h in saved])
+        logger = get_logger()
+        handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        self.assertTrue(handlers, "expected a file handler")
+        self.assertTrue(
+            all(isinstance(h, RotatingFileHandler) for h in handlers),
+            "file handler should rotate",
+        )
+
+    def test_zero_max_bytes_disables_rotation(self):
+        """Operators handing the file to an external logrotate can opt out."""
+        config = {
+            "app": {
+                "logger": {"level": "info", "filename": "icloud.log", "max_bytes": 0},
+            },
+        }
+        self.assertEqual(src.get_logger_config(config=config)["max_bytes"], 0)


### PR DESCRIPTION
`get_logger` uses a plain `logging.FileHandler` and nothing rotates or truncates it. A line is written per file *considered* each cycle, so the log scales with library size × sync frequency rather than with activity. An install syncing ~294k photos twice a day reached 5.8 GB, almost all of it `Downloading ...` for files already present.

Switches to `RotatingFileHandler`, 50 MB × 3 backups (200 MB worst case). Configurable via `app.logger.max_bytes` and `app.logger.backup_count`; `max_bytes: 0` disables rotation for setups using an external logrotate.

Defaults only change behaviour once a log passes 50 MB. Tests cover the defaults, the overrides, the disable case, and that the installed handler rotates. Documented in `config.yaml`.