### PR TITLE
fix: do not let recoverable failures exit the sync loop

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -48,7 +48,10 @@ def read_config(config_path=DEFAULT_CONFIG_FILE_PATH):
 def get_logger_config(config):
     """Get logger config."""
     logger_config = {}
-    if "logger" not in config["app"]:
+    # ``read_config`` returns None when config.yaml is missing, and a partial
+    # file may have no ``app`` section. Both reached ``config["app"]`` and
+    # raised -- from module scope, so the container could not start at all.
+    if not config or "logger" not in (config.get("app") or {}):
         return None
     config_app_logger = config["app"]["logger"]
     logger_config["level"] = (
@@ -126,7 +129,15 @@ def configure_icloudpy_logging():
 def get_logger():
     """Return logger."""
     logger = logging.getLogger()
-    logger_config = get_logger_config(config=read_config(config_path=os.environ.get(ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH)))
+    # This runs at import time, so anything raised here stops the container
+    # before it can report why -- and `restart: unless-stopped` turns that
+    # into a restart loop. A config too broken to parse is the sync loop's
+    # problem to report; here it just means default logging.
+    try:
+        config = read_config(config_path=os.environ.get(ENV_CONFIG_FILE_PATH_KEY, DEFAULT_CONFIG_FILE_PATH))
+    except Exception:  # noqa: BLE001 -- import-time: never crash on a bad config
+        config = None
+    logger_config = get_logger_config(config=config)
     if logger_config:
         level_name = logging.getLevelName(level=logger_config["level"].upper())
         logger.setLevel(level=level_name)

--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -774,6 +774,25 @@ def get_photos_folder_format(config: dict) -> str | None:
     return fmt
 
 
+def get_photos_request_timeout(config: dict) -> int:
+    """Return the HTTP read timeout for photo downloads, in seconds.
+
+    Drive downloads have had ``drive.request_timeout`` for a while; photo
+    downloads had no timeout at all, so a stalled connection to Apple's CDN
+    blocked its worker thread forever. The process stays alive and the
+    container stays "healthy" while the sync never finishes.
+
+    This is a between-bytes timeout, not a total-transfer budget, so large
+    videos are unaffected -- it only fires when the connection goes quiet.
+    """
+    config_path = ["photos", "request_timeout"]
+
+    if not traverse_config_path(config=config, config_path=config_path):
+        return DEFAULT_REQUEST_TIMEOUT_SEC
+
+    return get_config_value(config=config, config_path=config_path)
+
+
 # =============================================================================
 # Photos Filter Configuration Functions
 # =============================================================================

--- a/src/drive_file_download.py
+++ b/src/drive_file_download.py
@@ -10,7 +10,7 @@ import os
 from datetime import timezone
 from typing import Any
 
-from src import configure_icloudpy_logging, get_logger
+from src import DEFAULT_REQUEST_TIMEOUT_SEC, configure_icloudpy_logging, get_logger
 from src.drive_package_processing import process_package
 
 # Configure icloudpy logging immediately after import
@@ -19,7 +19,9 @@ configure_icloudpy_logging()
 LOGGER = get_logger()
 
 
-def download_file(item: Any, local_file: str) -> str | None:
+def download_file(
+    item: Any, local_file: str, timeout: int = DEFAULT_REQUEST_TIMEOUT_SEC,
+) -> str | None:
     """Download a file from iCloud to local filesystem.
 
     This function handles the actual download of files from iCloud, including
@@ -28,6 +30,10 @@ def download_file(item: Any, local_file: str) -> str | None:
     Args:
         item: iCloud file item to download
         local_file: Local path to save the file
+        timeout: HTTP read timeout in seconds. Without one a stalled
+            connection blocks its worker thread for the life of the
+            process -- nothing raises, so nothing retries and nothing
+            restarts, and the sync simply stops.
 
     Returns:
         Path to the downloaded/processed file, or None if download failed
@@ -37,7 +43,7 @@ def download_file(item: Any, local_file: str) -> str | None:
 
     LOGGER.info(f"Downloading {local_file} ...")
     try:
-        with item.open(stream=True) as response:
+        with item.open(stream=True, timeout=timeout) as response:
             with open(local_file, "wb") as file_out:
                 for chunk in response.iter_content(4 * 1024 * 1024):
                     file_out.write(chunk)

--- a/src/drive_parallel_download.py
+++ b/src/drive_parallel_download.py
@@ -14,7 +14,12 @@ from threading import Lock
 from typing import Any
 from urllib.parse import unquote
 
-from src import config_parser, configure_icloudpy_logging, get_logger
+from src import (
+    DEFAULT_REQUEST_TIMEOUT_SEC,
+    config_parser,
+    configure_icloudpy_logging,
+    get_logger,
+)
 from src.drive_file_download import download_file
 from src.drive_file_existence import file_exists, is_package, package_exists
 from src.drive_filtering import wanted_file
@@ -89,6 +94,7 @@ def collect_file_for_download(
             "local_file": local_file,
             "is_package": True,
             "files": files,
+            "timeout": config_parser.get_drive_request_timeout(config),
         }
 
     # File/directory doesn't exist locally (or was an outdated regular file that needs
@@ -102,6 +108,7 @@ def collect_file_for_download(
         "local_file": local_file,
         "is_package": item_is_package,
         "files": files,
+        "timeout": timeout,
     }
 
 
@@ -122,7 +129,11 @@ def download_file_task(download_info: dict[str, Any]) -> bool:
     LOGGER.debug(f"[Thread] Starting download of {local_file}")
 
     try:
-        downloaded_file = download_file(item=item, local_file=local_file)
+        downloaded_file = download_file(
+            item=item,
+            local_file=local_file,
+            timeout=download_info.get("timeout", DEFAULT_REQUEST_TIMEOUT_SEC),
+        )
         if not downloaded_file:
             return False
 

--- a/src/photo_download_manager.py
+++ b/src/photo_download_manager.py
@@ -10,7 +10,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 
-from src import config_parser, get_logger
+from src import DEFAULT_REQUEST_TIMEOUT_SEC, config_parser, get_logger
 from src.hardlink_registry import HardlinkRegistry
 from src.photo_file_utils import create_hardlink, download_photo_from_server
 from src.photo_path_utils import (
@@ -37,6 +37,7 @@ class DownloadTaskInfo:
         photo_path: str,
         hardlink_source: str | None = None,
         hardlink_registry: HardlinkRegistry | None = None,
+        timeout: int = DEFAULT_REQUEST_TIMEOUT_SEC,
     ):
         """Initialize download task info.
 
@@ -46,12 +47,14 @@ class DownloadTaskInfo:
             photo_path: Target path for photo download
             hardlink_source: Path to existing file for hardlink creation
             hardlink_registry: Registry for tracking downloaded files
+            timeout: HTTP read timeout for the download, in seconds
         """
         self.photo = photo
         self.file_size = file_size
         self.photo_path = photo_path
         self.hardlink_source = hardlink_source
         self.hardlink_registry = hardlink_registry
+        self.timeout = timeout
 
 
 def get_max_threads_for_download(config) -> int:
@@ -209,7 +212,12 @@ def execute_download_task(task_info: DownloadTaskInfo) -> bool:
                 LOGGER.warning(f"Hard link creation failed, downloading {task_info.photo_path} instead")
 
         # Download the photo
-        result = download_photo_from_server(task_info.photo, task_info.file_size, task_info.photo_path)
+        result = download_photo_from_server(
+            task_info.photo,
+            task_info.file_size,
+            task_info.photo_path,
+            timeout=task_info.timeout,
+        )
         if result and task_info.hardlink_registry is not None:
             # Register for future hard links if enabled
             task_info.hardlink_registry.register_photo_path(
@@ -240,6 +248,12 @@ def execute_parallel_downloads(download_tasks: list[DownloadTaskInfo], config) -
         return 0, 0
 
     max_threads = get_max_threads_for_download(config)
+
+    # Resolved once here rather than per task: without it a stalled CDN
+    # connection blocks its worker thread for the life of the process.
+    timeout = config_parser.get_photos_request_timeout(config)
+    for task in download_tasks:
+        task.timeout = timeout
 
     # Count hardlink tasks vs download tasks for logging
     hardlink_tasks = sum(1 for task in download_tasks if task.hardlink_source)

--- a/src/photo_file_utils.py
+++ b/src/photo_file_utils.py
@@ -13,7 +13,7 @@ import threading
 from datetime import timezone
 from urllib.parse import urlencode
 
-from src import get_logger
+from src import DEFAULT_REQUEST_TIMEOUT_SEC, get_logger
 
 LOGGER = get_logger()
 
@@ -288,7 +288,13 @@ def create_hardlink(source_path: str, destination_path: str) -> bool:
         return False
 
 
-def download_photo_from_server(photo, file_size: str, destination_path: str, max_retries: int = 1) -> bool:
+def download_photo_from_server(
+    photo,
+    file_size: str,
+    destination_path: str,
+    max_retries: int = 1,
+    timeout: int = DEFAULT_REQUEST_TIMEOUT_SEC,
+) -> bool:
     """Download photo from iCloud server to local path.
 
     This function implements automatic retry logic for HTTP 410 (Gone) errors,
@@ -301,6 +307,8 @@ def download_photo_from_server(photo, file_size: str, destination_path: str, max
         file_size: File size variant (original, medium, thumb, etc.)
         destination_path: Local path where photo should be saved
         max_retries: Maximum number of retries on 410 errors (default: 1)
+        timeout: HTTP read timeout in seconds. Without one a stalled CDN
+            connection blocks the worker thread forever.
 
     Returns:
         True if download was successful, False otherwise
@@ -316,7 +324,7 @@ def download_photo_from_server(photo, file_size: str, destination_path: str, max
 
     while attempt < max_attempts:  # noqa: PERF203
         try:
-            download = photo.download(file_size)
+            download = photo.download(file_size, timeout=timeout)
             with open(destination_path, "wb") as file_out:
                 shutil.copyfileobj(download.raw, file_out)
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -5,6 +5,7 @@ import datetime
 import os
 from time import sleep
 
+import requests
 from icloudpy import ICloudPyService, exceptions, utils
 
 from src import (
@@ -59,6 +60,10 @@ def _read_trust_cookie_expiry(api) -> datetime.datetime | None:
 # ``_resolve_dashboard_url``) so the advice appears once per process,
 # not once per sync-loop iteration.
 _WEB_UI_PUBLIC_URL_WARNED = False
+
+# Minimum wait after a failed sign-in. Apple answers a throttled account
+# with 409 on /signin/init; retrying sooner just extends the lockout.
+_AUTH_BACKOFF_FLOOR_SEC = 1800
 
 
 def _resolve_dashboard_url(config) -> str | None:
@@ -797,6 +802,27 @@ def _handle_2fa_required(config, username: str, sync_state: SyncState):
     return True
 
 
+def _handle_auth_transport_error(config, username: str, sync_state: SyncState, error):
+    """Back off after a sign-in failure Apple did not express as a 2FA prompt.
+
+    Uses at least ``_AUTH_BACKOFF_FLOOR_SEC`` regardless of the configured
+    retry interval: the errors that land here (notably Apple's 409 on
+    ``/signin/init``) mean "you are trying too often", so honouring a short
+    interval would make it worse.
+
+    Returns True to keep looping, False to exit.
+    """
+    LOGGER.error(f"Sign-in failed and will be retried: {error!s}")
+    sleep_for = config_parser.get_retry_login_interval(config=config)
+    if sleep_for < 0:
+        LOGGER.info("retry_login_interval is < 0, exiting ...")
+        return False
+    sleep_for = max(sleep_for, _AUTH_BACKOFF_FLOOR_SEC)
+    _log_retry_time(sleep_for)
+    sleep(sleep_for)
+    return True
+
+
 def _handle_password_error(config, username: str, sync_state: SyncState):
     """
     Handle password not available error.
@@ -1123,6 +1149,20 @@ def sync(dry_run: bool = False, check_files: int | None = None):
 
             except exceptions.ICloudPyNoStoredPasswordAvailableException:
                 if not _handle_password_error(config, username, sync_state):
+                    break
+                continue
+            except (
+                exceptions.ICloudPyAPIResponseException,
+                requests.exceptions.RequestException,
+            ) as e:
+                # Apple refuses sign-in for reasons other than "2FA needed":
+                # 409 when it is throttling the account, 5xx when it is
+                # having a bad day, plus ordinary network faults. None of
+                # these are fatal, but letting them escape kills the process
+                # -- and with `restart: unless-stopped` that becomes a crash
+                # loop that re-authenticates every few seconds, which is the
+                # fastest possible way to deepen a throttle.
+                if not _handle_auth_transport_error(config, username, sync_state, e):
                     break
                 continue
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -823,6 +823,36 @@ def _handle_auth_transport_error(config, username: str, sync_state: SyncState, e
     return True
 
 
+def _handle_sync_error(config, error, drive_sync_interval, photos_sync_interval):
+    """Back off after a failure that happened *after* a successful sign-in.
+
+    Anything raised once ``api`` exists is a service problem, not an auth
+    problem: a zone that is unavailable, a 5xx on a download, a connection
+    dropped mid-transfer. Reporting those as sign-in failures sends the user
+    to re-authenticate for no reason.
+
+    The interval matters as much as the wording. Every handler here ends in
+    ``continue``, which skips ``_calculate_next_sync_schedule`` -- so the
+    countdown timers never advance and both services stay enabled. Retrying
+    on the short login interval therefore re-enumerates the whole library
+    every few minutes. Wait at least as long as the shortest configured sync
+    interval instead: never poll a broken service faster than a working one.
+
+    Returns True to keep looping, False to exit.
+    """
+    LOGGER.error(f"Sync failed and will be retried: {error!s}")
+    sleep_for = config_parser.get_retry_login_interval(config=config)
+    if sleep_for < 0:
+        LOGGER.info("retry_login_interval is < 0, exiting ...")
+        return False
+    configured = [i for i in (drive_sync_interval, photos_sync_interval) if i > 0]
+    if configured:
+        sleep_for = max(sleep_for, min(configured))
+    _log_retry_time(sleep_for)
+    sleep(sleep_for)
+    return True
+
+
 def _handle_password_error(config, username: str, sync_state: SyncState):
     """
     Handle password not available error.
@@ -1030,8 +1060,10 @@ def sync(dry_run: bool = False, check_files: int | None = None):
             pass
 
         if username:
+            authenticated = False
             try:
                 api = _authenticate_and_get_api(config, username)
+                authenticated = True
 
                 # Dry-run path: authenticate, enumerate, log, exit.
                 # Skips the entire sync + notification + retry pipeline.
@@ -1153,19 +1185,33 @@ def sync(dry_run: bool = False, check_files: int | None = None):
                 continue
             except exceptions.ICloudPyServiceNotActivatedException as e:
                 # A zone or service being unavailable says nothing about the
-                # sign-in, so it must not earn the rate-limit backoff meant
-                # for "you are trying too often". Wait the ordinary interval.
-                LOGGER.error(f"Service unavailable, will retry: {e!s}")
-                sleep_for = config_parser.get_retry_login_interval(config=config)
-                if sleep_for < 0:
+                # sign-in whenever it surfaces, so it never earns the
+                # rate-limit backoff. Listed ahead of the broader catch
+                # below because it subclasses it.
+                if not _handle_sync_error(
+                    config,
+                    e,
+                    drive_sync_interval,
+                    photos_sync_interval,
+                ):
                     break
-                _log_retry_time(sleep_for)
-                sleep(sleep_for)
                 continue
             except (
                 exceptions.ICloudPyAPIResponseException,
                 requests.exceptions.RequestException,
             ) as e:
+                # Any other failure raised after the sign-in succeeded is a
+                # service problem, not an auth problem -- and must not earn
+                # the backoff meant for "you are trying too often" either.
+                if authenticated:
+                    if not _handle_sync_error(
+                        config,
+                        e,
+                        drive_sync_interval,
+                        photos_sync_interval,
+                    ):
+                        break
+                    continue
                 # Apple refuses sign-in for reasons other than "2FA needed":
                 # 409 when it is throttling the account, 5xx when it is
                 # having a bad day, plus ordinary network faults. None of

--- a/src/sync.py
+++ b/src/sync.py
@@ -1151,6 +1151,17 @@ def sync(dry_run: bool = False, check_files: int | None = None):
                 if not _handle_password_error(config, username, sync_state):
                     break
                 continue
+            except exceptions.ICloudPyServiceNotActivatedException as e:
+                # A zone or service being unavailable says nothing about the
+                # sign-in, so it must not earn the rate-limit backoff meant
+                # for "you are trying too often". Wait the ordinary interval.
+                LOGGER.error(f"Service unavailable, will retry: {e!s}")
+                sleep_for = config_parser.get_retry_login_interval(config=config)
+                if sleep_for < 0:
+                    break
+                _log_retry_time(sleep_for)
+                sleep(sleep_for)
+                continue
             except (
                 exceptions.ICloudPyAPIResponseException,
                 requests.exceptions.RequestException,

--- a/src/sync.py
+++ b/src/sync.py
@@ -10,6 +10,7 @@ from icloudpy import ICloudPyService, exceptions, utils
 
 from src import (
     DEFAULT_CONFIG_FILE_PATH,
+    DEFAULT_RETRY_LOGIN_INTERVAL_SEC,
     ENV_CONFIG_FILE_PATH_KEY,
     ENV_ICLOUD_PASSWORD_KEY,
     config_parser,
@@ -1027,7 +1028,23 @@ def sync(dry_run: bool = False, check_files: int | None = None):
     startup_logged = False
 
     while True:
-        config = _load_configuration()
+        # A config that cannot be read must not kill the daemon. On a NAS the
+        # volume holding config.yaml can lag behind container start or go away
+        # mid-run, and a half-written file (the user editing it live) raises
+        # out of the YAML parser. Either way the traceback escapes the loop,
+        # and `restart: unless-stopped` turns that into a restart loop.
+        try:
+            config = _load_configuration()
+        except Exception as e:  # noqa: BLE001 -- any parse fault must not be fatal
+            LOGGER.error(f"Config file could not be read, retrying: {e!s}")
+            config = None
+        if config is None:
+            if dry_run:
+                # A dry run is a one-shot check with nothing to wait for.
+                LOGGER.error("DRY RUN: no readable config, nothing to check.")
+                return
+            sleep(DEFAULT_RETRY_LOGIN_INTERVAL_SEC)
+            continue
 
         # Log sync intervals once at startup
         if not startup_logged:

--- a/src/sync_drive.py
+++ b/src/sync_drive.py
@@ -116,7 +116,11 @@ def process_file(
         timeout = config_parser.get_drive_request_timeout(config)
         item_is_package = is_package(item=item, timeout=timeout)
 
-    local_file = download_file(item=item, local_file=local_file)
+    local_file = download_file(
+        item=item,
+        local_file=local_file,
+        timeout=config_parser.get_drive_request_timeout(config),
+    )
     if local_file and item_is_package:
         for f in Path(local_file).glob("**/*"):
             f = str(f)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -834,3 +834,21 @@ class TestConfigParser(unittest.TestCase):
         config = {"app": {"usage_tracking": {"enabled": None}}}
         result = config_parser.get_usage_tracking_enabled(config)
         self.assertTrue(result)
+
+
+class TestPhotosRequestTimeout(unittest.TestCase):
+    """Photo downloads had no timeout at all, so a stalled connection to
+    Apple's CDN blocked its worker thread for the life of the process. The
+    container stays alive and 'healthy' while the sync never finishes."""
+
+    def test_default_matches_the_drive_option(self):
+        from src import DEFAULT_REQUEST_TIMEOUT_SEC
+
+        self.assertEqual(
+            config_parser.get_photos_request_timeout(config={}),
+            DEFAULT_REQUEST_TIMEOUT_SEC,
+        )
+
+    def test_configured_value_is_used(self):
+        cfg = {"photos": {"request_timeout": 120}}
+        self.assertEqual(config_parser.get_photos_request_timeout(config=cfg), 120)

--- a/tests/test_src_init.py
+++ b/tests/test_src_init.py
@@ -47,3 +47,25 @@ class TestSrcInit(unittest.TestCase):
         number_of_handlers = len(logger.handlers)
         logger = get_logger()
         self.assertEqual(len(logger.handlers), number_of_handlers)
+
+
+class TestUnreadableConfigDoesNotBreakImport(unittest.TestCase):
+    """``LOGGER = get_logger()`` runs at module scope, so anything raised
+    while reading config.yaml stops the container before it can report why
+    -- and ``restart: unless-stopped`` turns that into a restart loop."""
+
+    def test_missing_config_falls_back_to_default_logging(self):
+        """``read_config`` returns None when the file is not there."""
+        from src import get_logger_config
+
+        self.assertIsNone(get_logger_config(config=None))
+
+    def test_partial_config_without_an_app_section(self):
+        from src import get_logger_config
+
+        self.assertIsNone(get_logger_config(config={"drive": {}}))
+
+    @patch("src.read_config", side_effect=ValueError("could not parse yaml"))
+    def test_unparseable_config_does_not_raise(self, _mock_read_config):
+        """A half-written file must not take the process down at import."""
+        self.assertIsNotNone(get_logger())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1219,3 +1219,118 @@ class TestInterruptibleSleep(unittest.TestCase):
         # Exited after the second chunk -> 2 sleeps + 2 polls.
         self.assertEqual(mock_sleep.call_count, 2)
         self.assertEqual(mock_pending.call_count, 2)
+
+
+class TestSigninTransportFailures(unittest.TestCase):
+    """A sign-in failure Apple does not express as a 2FA prompt must not
+    end the process.
+
+    Only the missing-password exception was caught, so a bare requests
+    HTTPError from ICloudPyService construction escaped, exited, and -- with
+    the container's restart policy -- became a loop that re-authenticated
+    every few seconds. Apple answers a rate-limited account with 409 on
+    /signin/init, so the loop was hammering the very condition it was
+    reacting to."""
+
+    def test_backoff_floor_beats_a_short_retry_interval(self):
+        from unittest.mock import MagicMock, patch
+
+        from src import sync
+
+        config = {"app": {"credentials": {"retry_login_interval": 60}}}
+        with patch.object(sync, "sleep") as slept:
+            keep_going = sync._handle_auth_transport_error(  # noqa: SLF001
+                config,
+                "a@icloud.com",
+                MagicMock(),
+                RuntimeError("409"),
+            )
+        self.assertTrue(keep_going)
+        self.assertGreaterEqual(
+            slept.call_args.args[0],
+            sync._AUTH_BACKOFF_FLOOR_SEC,  # noqa: SLF001
+        )
+
+    def test_negative_interval_exits(self):
+        from unittest.mock import MagicMock
+
+        from src import sync
+
+        config = {"app": {"credentials": {"retry_login_interval": -1}}}
+        self.assertFalse(
+            sync._handle_auth_transport_error(  # noqa: SLF001
+                config,
+                "a@icloud.com",
+                MagicMock(),
+                RuntimeError("409"),
+            ),
+        )
+
+    def test_loop_retries_after_a_recoverable_failure(self):
+        """The continue path: the handler says keep going, the loop loops."""
+        from unittest.mock import patch
+
+        import requests
+
+        from src import sync
+
+        config = {
+            "app": {"credentials": {"username": "a@icloud.com"}},
+            "drive": {"destination": "drive"},
+        }
+        with (
+            patch.object(sync, "_load_configuration", return_value=config),
+            patch.object(sync, "alive"),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(
+                sync,
+                "_authenticate_and_get_api",
+                side_effect=requests.exceptions.HTTPError("409 Client Error"),
+            ),
+            patch.object(
+                sync,
+                "_handle_auth_transport_error",
+                side_effect=[True, False],
+            ) as handler,
+            patch("src.config_parser.get_username", return_value="a@icloud.com"),
+        ):
+            sync.sync()
+        self.assertEqual(handler.call_count, 2)
+
+    def test_http_error_is_a_request_exception(self):
+        """Guard the except clause: the crash was an HTTPError, so the
+        handler only helps if that type is actually caught."""
+        import requests
+
+        self.assertTrue(
+            issubclass(
+                requests.exceptions.HTTPError,
+                requests.exceptions.RequestException,
+            ),
+        )
+
+    def test_loop_absorbs_an_http_error_instead_of_dying(self):
+        from unittest.mock import patch
+
+        import requests
+
+        from src import sync
+
+        config = {
+            "app": {
+                "credentials": {"username": "a@icloud.com", "retry_login_interval": -1},
+            },
+            "drive": {"destination": "drive"},
+        }
+        with (
+            patch.object(sync, "_load_configuration", return_value=config),
+            patch.object(sync, "alive"),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(
+                sync,
+                "_authenticate_and_get_api",
+                side_effect=requests.exceptions.HTTPError("409 Client Error"),
+            ),
+            patch("src.config_parser.get_username", return_value="a@icloud.com"),
+        ):
+            sync.sync()  # must return, not raise

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1402,3 +1402,123 @@ class TestServiceUnavailableIsNotASigninFailure(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 sync.sync()
         self.assertGreaterEqual(slept.call_count, 1)
+
+
+class TestPostAuthFailuresAreNotSigninFailures(unittest.TestCase):
+    """Errors raised once ``api`` exists are service faults, not auth faults.
+
+    The sync loop wraps authentication and the whole sync in one ``try``, so
+    without routing on "did we get past sign-in" a 5xx on a photo download is
+    reported to the user as a sign-in failure and earns the rate-limit
+    backoff. Worse, every handler ends in ``continue``, which skips
+    ``_calculate_next_sync_schedule`` -- the countdown timers never advance,
+    so the short login-retry interval re-enumerates the entire library."""
+
+    def _config(self, retry=600, drive_interval=43200):
+        return {
+            "app": {"credentials": {"username": "a@icloud.com", "retry_login_interval": retry}},
+            "drive": {"destination": "drive", "sync_interval": drive_interval},
+        }
+
+    def test_failure_after_signin_does_not_use_the_auth_backoff(self):
+        from unittest.mock import MagicMock, patch
+
+        from icloudpy import exceptions
+
+        from src import sync
+
+        api = MagicMock()
+        api.requires_2sa = False
+        error = exceptions.ICloudPyAPIResponseException("500 Server Error")
+        with (
+            patch.object(sync, "_load_configuration", return_value=self._config(retry=-1)),
+            patch.object(sync, "alive"),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(sync, "_authenticate_and_get_api", return_value=api),
+            patch.object(sync, "_maybe_warn_trust_expiring"),
+            patch.object(sync, "_perform_drive_sync", side_effect=error),
+            patch.object(sync, "_handle_auth_transport_error") as auth_handler,
+            patch("src.config_parser.get_username", return_value="a@icloud.com"),
+        ):
+            sync.sync()
+        auth_handler.assert_not_called()
+
+    def test_failure_before_signin_still_uses_the_auth_backoff(self):
+        """The throttle case must keep its long floor."""
+        from unittest.mock import patch
+
+        from icloudpy import exceptions
+
+        from src import sync
+
+        error = exceptions.ICloudPyAPIResponseException("409 Conflict")
+        with (
+            patch.object(sync, "_load_configuration", return_value=self._config()),
+            patch.object(sync, "alive"),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(sync, "_authenticate_and_get_api", side_effect=error),
+            patch.object(sync, "_handle_auth_transport_error", return_value=False) as auth_handler,
+            patch("src.config_parser.get_username", return_value="a@icloud.com"),
+        ):
+            sync.sync()
+        auth_handler.assert_called_once()
+
+    def test_retry_never_polls_faster_than_the_sync_interval(self):
+        """A broken service must not be polled faster than a working one."""
+        from unittest.mock import patch
+
+        from src import sync
+
+        with patch.object(sync, "sleep") as slept:
+            kept_looping = sync._handle_sync_error(  # noqa: SLF001
+                self._config(retry=600, drive_interval=43200),
+                Exception("boom"),
+                43200,
+                -1,
+            )
+        self.assertTrue(kept_looping)
+        slept.assert_called_once_with(43200)
+
+    def test_retry_falls_back_to_the_login_interval_when_nothing_is_configured(self):
+        from unittest.mock import patch
+
+        from src import sync
+
+        with patch.object(sync, "sleep") as slept:
+            sync._handle_sync_error(  # noqa: SLF001
+                self._config(retry=600), Exception("boom"), -1, -1,
+            )
+        slept.assert_called_once_with(600)
+
+    def test_negative_retry_interval_exits(self):
+        from src import sync
+
+        self.assertFalse(
+            sync._handle_sync_error(  # noqa: SLF001
+                self._config(retry=-1), Exception("boom"), 43200, -1,
+            ),
+        )
+    def test_the_loop_continues_after_a_post_signin_failure(self):
+        """A service fault is retried, not fatal: the daemon keeps running."""
+        from unittest.mock import MagicMock, patch
+
+        from icloudpy import exceptions
+
+        from src import sync
+
+        api = MagicMock()
+        api.requires_2sa = False
+        error = exceptions.ICloudPyAPIResponseException("500 Server Error")
+        with (
+            patch.object(sync, "_load_configuration", return_value=self._config()),
+            patch.object(sync, "alive"),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(sync, "_authenticate_and_get_api", return_value=api),
+            patch.object(sync, "_maybe_warn_trust_expiring"),
+            patch.object(sync, "_perform_drive_sync", side_effect=error),
+            # True keeps the loop alive for a second pass, False ends the test.
+            patch.object(sync, "_handle_sync_error", side_effect=[True, False]) as handler,
+            patch("src.config_parser.get_username", return_value="a@icloud.com"),
+        ):
+            sync.sync()
+        self.assertEqual(handler.call_count, 2)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1334,3 +1334,71 @@ class TestSigninTransportFailures(unittest.TestCase):
             patch("src.config_parser.get_username", return_value="a@icloud.com"),
         ):
             sync.sync()  # must return, not raise
+
+
+class TestServiceUnavailableIsNotASigninFailure(unittest.TestCase):
+    """A zone or service being unavailable says nothing about the sign-in.
+
+    ICloudPyServiceNotActivatedException subclasses
+    ICloudPyAPIResponseException, so catching the parent to absorb sign-in
+    faults also swallows "Zone does not exist" -- which then earns the
+    rate-limit backoff for an account that is signed in perfectly well."""
+
+    def test_it_is_a_subclass_of_the_broader_exception(self):
+        """The reason the broad catch swallows it."""
+        from icloudpy import exceptions
+
+        self.assertTrue(
+            issubclass(
+                exceptions.ICloudPyServiceNotActivatedException,
+                exceptions.ICloudPyAPIResponseException,
+            ),
+        )
+
+    def test_zone_errors_use_the_ordinary_interval(self):
+        from unittest.mock import patch
+
+        from icloudpy import exceptions
+
+        from src import sync
+
+        config = {
+            "app": {"credentials": {"username": "a@icloud.com", "retry_login_interval": -1}},
+            "drive": {"destination": "drive"},
+        }
+        error = exceptions.ICloudPyServiceNotActivatedException("Zone does not exist")
+        with (
+            patch.object(sync, "_load_configuration", return_value=config),
+            patch.object(sync, "alive"),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(sync, "_authenticate_and_get_api", side_effect=error),
+            patch.object(sync, "_handle_auth_transport_error") as auth_handler,
+            patch("src.config_parser.get_username", return_value="a@icloud.com"),
+        ):
+            sync.sync()
+        auth_handler.assert_not_called()
+
+    def test_zone_errors_wait_and_retry(self):
+        """Not fatal: the account is fine, the service is not."""
+        from unittest.mock import patch
+
+        from icloudpy import exceptions
+
+        from src import sync
+
+        config = {
+            "app": {"credentials": {"username": "a@icloud.com"}},
+            "drive": {"destination": "drive"},
+        }
+        error = exceptions.ICloudPyServiceNotActivatedException("Zone does not exist")
+        with (
+            patch.object(sync, "_load_configuration", return_value=config),
+            patch.object(sync, "alive"),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(sync, "_authenticate_and_get_api", side_effect=error),
+            patch.object(sync, "sleep", side_effect=[None, SystemExit]) as slept,
+            patch("src.config_parser.get_username", return_value="a@icloud.com"),
+        ):
+            with self.assertRaises(SystemExit):
+                sync.sync()
+        self.assertGreaterEqual(slept.call_count, 1)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1522,3 +1522,61 @@ class TestPostAuthFailuresAreNotSigninFailures(unittest.TestCase):
         ):
             sync.sync()
         self.assertEqual(handler.call_count, 2)
+
+
+class TestUnreadableConfigDoesNotKillTheDaemon(unittest.TestCase):
+    """A missing or half-written config.yaml must not become a restart loop.
+
+    On a NAS the volume holding the config can lag behind container start or
+    vanish mid-run. ``read_config`` returns None for a missing file, and the
+    downstream ``"drive" not in config`` raised TypeError straight out of the
+    loop -- which ``restart: unless-stopped`` turns into a crash loop."""
+
+    def test_missing_config_waits_instead_of_raising(self):
+        from unittest.mock import patch
+
+        from src import sync
+
+        # Second pass returns a config whose intervals are negative so the
+        # loop exits; the first pass is the one under test.
+        configs = [None, {"app": {"credentials": {"username": None}}}]
+        with (
+            patch.object(sync, "_load_configuration", side_effect=configs),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(sync, "sleep") as slept,
+            patch.object(sync, "_interruptible_sleep"),
+            patch("src.config_parser.get_username", return_value=None),
+        ):
+            sync.sync()
+        slept.assert_called_once_with(600)
+
+    def test_unparseable_config_waits_instead_of_raising(self):
+        from unittest.mock import patch
+
+        from src import sync
+
+        side_effects = [
+            ValueError("could not parse yaml"),
+            {"app": {"credentials": {"username": None}}},
+        ]
+        with (
+            patch.object(sync, "_load_configuration", side_effect=side_effects),
+            patch.object(sync, "_log_sync_intervals_at_startup"),
+            patch.object(sync, "sleep") as slept,
+            patch.object(sync, "_interruptible_sleep"),
+            patch("src.config_parser.get_username", return_value=None),
+        ):
+            sync.sync()
+        slept.assert_called_once_with(600)
+
+    def test_dry_run_returns_instead_of_waiting(self):
+        from unittest.mock import patch
+
+        from src import sync
+
+        with (
+            patch.object(sync, "_load_configuration", return_value=None),
+            patch.object(sync, "sleep") as slept,
+        ):
+            sync.sync(dry_run=True)
+        slept.assert_not_called()

--- a/tests/test_sync_drive.py
+++ b/tests/test_sync_drive.py
@@ -4,6 +4,7 @@ __author__ = "Mandar Patil (mandarons@pm.me)"
 
 import os
 import shutil
+import tempfile
 import time
 import unittest
 from datetime import timezone
@@ -1960,3 +1961,31 @@ class TestSyncDrive(unittest.TestCase):
         self.assertNotIn("%CC%88", download_info["local_file"])
         self.assertNotIn("%2C", download_info["local_file"])
         self.assertNotIn("%25", download_info["local_file"])
+
+
+class TestDriveDownloadHasATimeout(unittest.TestCase):
+    """A drive download with no timeout blocks its worker thread for the life
+    of the process. Nothing raises, so nothing retries and nothing restarts --
+    the sync simply stops, while the container still looks healthy. Observed
+    live: a stalled drive download froze a sync for nearly three days."""
+
+    def test_the_timeout_reaches_the_stream_open(self):
+        from unittest.mock import MagicMock, patch
+
+        from src.drive_file_download import download_file
+
+        item = MagicMock()
+        item.open.return_value.__enter__.return_value.iter_content.return_value = []
+        with tempfile.TemporaryDirectory() as d, patch("src.drive_file_download.process_package"):
+            download_file(item=item, local_file=os.path.join(d, "f.bin"), timeout=61)
+        self.assertEqual(item.open.call_args.kwargs.get("timeout"), 61)
+
+    def test_the_worker_applies_the_task_timeout(self):
+        from unittest.mock import patch
+
+        from src import drive_parallel_download as m
+
+        with patch.object(m, "download_file", return_value=None) as dl:
+            m.download_file_task({"item": object(), "local_file": "/x",
+                                  "is_package": False, "files": set(), "timeout": 47})
+        self.assertEqual(dl.call_args.kwargs.get("timeout"), 47)

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -5,6 +5,7 @@ __author__ = "Mandar Patil (mandarons@pm.me)"
 import glob
 import os
 import shutil
+import tempfile
 import unittest
 from datetime import timezone
 from io import StringIO
@@ -453,7 +454,7 @@ class TestSyncPhotos(unittest.TestCase):
         """Test if download_photo has file size as None."""
 
         class MockPhoto:
-            def download(self, quality):
+            def download(self, quality, **kwargs):
                 raise icloudpy.exceptions.ICloudPyAPIResponseException
 
         self.assertFalse(sync_photos.download_photo(MockPhoto(), None, self.destination_path))
@@ -462,7 +463,7 @@ class TestSyncPhotos(unittest.TestCase):
         """Test if download_photo has destination path as None."""
 
         class MockPhoto:
-            def download(self, quality):
+            def download(self, quality, **kwargs):
                 raise icloudpy.exceptions.ICloudPyAPIResponseException
 
         self.assertFalse(sync_photos.download_photo(MockPhoto(), ["original"], None))
@@ -471,7 +472,7 @@ class TestSyncPhotos(unittest.TestCase):
         """Test if exception is thrown in dowonload_photo."""
 
         class MockPhoto:
-            def download(self, quality):
+            def download(self, quality, **kwargs):
                 raise icloudpy.exceptions.ICloudPyAPIResponseException
 
         self.assertFalse(sync_photos.download_photo(MockPhoto(), ["original"], self.destination_path))
@@ -788,7 +789,7 @@ class TestSyncPhotos(unittest.TestCase):
                 self.added_date = datetime.datetime(2021, 1, 1, 12, 0, 0)
                 self.id = "test_photo_id"
 
-            def download(self, file_size):
+            def download(self, file_size, **kwargs):
                 # Return a mock response with raw attribute
                 class MockResponse:
                     def __init__(self):
@@ -1454,7 +1455,7 @@ class TestSyncPhotos(unittest.TestCase):
                 self.added_date = datetime.datetime(2021, 1, 1, 12, 0, 0)
                 self.id = "test_photo_id"
 
-            def download(self, file_size):
+            def download(self, file_size, **kwargs):
                 # Return a mock response with raw attribute
                 class MockResponse:
                     def __init__(self):
@@ -2570,3 +2571,38 @@ class TestSyncPhotos(unittest.TestCase):
             )
         # Should return (0, 0) when sync_album_photos returns None
         self.assertEqual(result, (0, 0))
+
+
+class TestPhotoDownloadTimeout(unittest.TestCase):
+    """A download with no timeout blocks its worker thread forever."""
+
+    def test_the_timeout_reaches_the_download_call(self):
+        from unittest.mock import MagicMock, patch
+
+        from src.photo_file_utils import download_photo_from_server
+
+        photo = MagicMock()
+        photo.download.return_value.raw = StringIO("")
+        with tempfile.TemporaryDirectory() as d:
+            with patch("shutil.copyfileobj"):
+                download_photo_from_server(
+                    photo, "original", os.path.join(d, "x.jpg"), timeout=77,
+                )
+        self.assertEqual(photo.download.call_args.kwargs["timeout"], 77)
+
+    def test_the_configured_timeout_reaches_every_task(self):
+        from src import photo_download_manager as m
+
+        tasks = [
+            m.DownloadTaskInfo(photo=object(), file_size="original", photo_path="/a"),
+            m.DownloadTaskInfo(photo=object(), file_size="original", photo_path="/b"),
+        ]
+        cfg = {"photos": {"request_timeout": 45}, "app": {}}
+        from unittest.mock import patch
+
+        with patch.object(m, "ThreadPoolExecutor", side_effect=RuntimeError("stop")):
+            try:
+                m.execute_parallel_downloads(tasks, cfg)
+            except RuntimeError:
+                pass
+        self.assertEqual([t.timeout for t in tasks], [45, 45])


### PR DESCRIPTION
The sync loop exits on several failures that are retryable, and with `restart: unless-stopped` an exit becomes a restart loop. Four related fixes.

**Sign-in failures other than a 2FA prompt.** Apple answers `/signin/init` with 409 when it is throttling an account and 5xx when it is having a bad day; ordinary network faults land the same way. Only `ICloudPyNoStoredPasswordAvailableException` was caught, so any of those killed the process — which restarted and re-authenticated within seconds, deepening the throttle. Now retried with a 30-minute floor, because these specifically mean "you are trying too often".

**A service outage reported as a sign-in failure.** `ICloudPyServiceNotActivatedException` subclasses `ICloudPyAPIResponseException`, so the catch above also swallowed `ZONE_NOT_FOUND` from a per-service call and told the user to re-authenticate an account that was signed in fine.

**The retry interval after a mid-sync failure.** The loop wraps authentication and the whole sync in one `try`, so an error raised during a download was classified as a sign-in failure. Every handler also ends in `continue`, which skips `_calculate_next_sync_schedule` — the countdown timers never advance and both services stay enabled, so the short login-retry interval repeated a full library enumeration every few minutes. Failures are now routed on whether sign-in actually succeeded, and a post-sign-in failure waits at least as long as the shortest configured sync interval.

**An unreadable `config.yaml`.** `read_config` returns `None` when the file is missing, and a partial file may have no `app` section. Both reached `config["app"]` unguarded — once from `get_logger()` at module scope, so the container died on import with a bare `TypeError` and never reported the real problem, and once from the loop's oneshot check. Reachable on any boot where the volume holding the config lags behind the container. Logging now falls back to defaults and the loop waits for the file.

Tests cover each path. Suite at 100% coverage.
