### PR TITLE
feat: refresh the trust token before it expires

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,12 @@ app:
   # no_tls: true
   # valid values are - global (default - uses .com) or china (uses .com.cn)
   region: global
+  # Re-trust the session when the trust token has this many days left.
+  # trust_session mints a fresh token whenever it is called on a live
+  # session, so refreshing on a schedule keeps the token on disk young and
+  # lets a container restart resume without a second factor. Must exceed
+  # trust_expiry_warn_days. Set to 0 to disable. Default 14.
+  # trust_refresh_days: 14
 drive:
   destination: "drive"
   # Remove local files that are not present on server (i.e. files delete on server)

--- a/src/config_parser.py
+++ b/src/config_parser.py
@@ -394,6 +394,29 @@ def get_trust_expiry_warn_days(config: dict) -> int:
     )
 
 
+def get_trust_refresh_days(config: dict) -> int:
+    """Proactively re-trust when the cookie has this many days left.
+
+    Default 14. Apple's trust window is finite, but ``trust_session``
+    mints a fresh token whenever it is called on a live session, so
+    re-trusting on a schedule keeps the *persisted* token young. That is
+    what lets a container restart resume without a second factor -- the
+    common failure mode otherwise is a long-running process holding a
+    valid in-memory session while the token on disk quietly expires,
+    stranding the next cold start on a 2FA prompt.
+
+    Must exceed ``trust_expiry_warn_days`` for the refresh to get a
+    chance before the warning fires. Set to 0 to disable.
+    """
+    return int(
+        get_config_value_or_default(
+            config=config,
+            config_path=["app", "trust_refresh_days"],
+            default=14,
+        ),
+    )
+
+
 def get_app_max_threads(config: dict) -> int:
     """Return app-level max threads from config with support for 'auto' value.
 

--- a/src/sync.py
+++ b/src/sync.py
@@ -94,6 +94,51 @@ def _resolve_dashboard_url(config) -> str | None:
     return f"http://{host}:{port}"
 
 
+def _maybe_refresh_trust(config, api) -> None:
+    """Re-trust the session before its token ages out.
+
+    ``trust_session`` asks Apple for a new ``X-Apple-TwoSV-Trust-Token``
+    and icloudpy persists it to ``session_data``. Calling it while the
+    session is still healthy therefore rolls the window forward, so a
+    restart at any later point finds a young token and resumes without
+    prompting for a second factor.
+
+    This matters most for accounts where the second factor is expensive
+    or impossible to satisfy headlessly (hardware security keys, where
+    Apple refuses to send a 6-digit code at all).
+
+    Best-effort: never raises into the sync loop.
+    """
+    try:
+        threshold = config_parser.get_trust_refresh_days(config=config)
+        if threshold <= 0:
+            return
+        expires_at = _read_trust_cookie_expiry(api)
+        if expires_at is None:
+            return
+        days_remaining = (
+            expires_at - datetime.datetime.now(tz=datetime.timezone.utc)
+        ).days
+        if days_remaining > threshold:
+            return
+        LOGGER.info(
+            f"Trust token has {days_remaining}d left (threshold {threshold}d) -- refreshing.",
+        )
+        if api.trust_session():
+            refreshed = _read_trust_cookie_expiry(api)
+            LOGGER.info(
+                "Trust refreshed; now expires "
+                f"{refreshed.isoformat() if refreshed else 'unknown'}.",
+            )
+        else:
+            LOGGER.warning(
+                "Proactive trust refresh was declined by Apple -- a second "
+                "factor will be needed at the next cold start.",
+            )
+    except Exception as e:  # pragma: no cover - never break sync over a refresh
+        LOGGER.warning(f"trust refresh failed: {e!s}")
+
+
 def _maybe_warn_trust_expiring(config, api, username: str) -> None:
     """Fire the trust-expiring notification once when crossing threshold.
 
@@ -1023,6 +1068,7 @@ def sync(dry_run: bool = False, check_files: int | None = None):
                     # Trust-window check: record current cookie expiry and
                     # fire a pre-emptive warning once if it's about to lapse.
                     # Best-effort: any failure is logged + swallowed inside.
+                    _maybe_refresh_trust(config, api)
                     _maybe_warn_trust_expiring(config, api, username)
 
                     # Create summary for this sync cycle

--- a/tests/test_trust_expiry.py
+++ b/tests/test_trust_expiry.py
@@ -439,3 +439,121 @@ class TestWebSignalsTrustState(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestGetTrustRefreshDays(unittest.TestCase):
+    """``app.trust_refresh_days`` reader."""
+
+    def test_default_is_fourteen(self):
+        from src import config_parser
+
+        self.assertEqual(config_parser.get_trust_refresh_days(config={}), 14)
+
+    def test_override(self):
+        from src import config_parser
+
+        cfg = {"app": {"trust_refresh_days": 3}}
+        self.assertEqual(config_parser.get_trust_refresh_days(config=cfg), 3)
+
+
+class TestMaybeRefreshTrust(unittest.TestCase):
+    """``sync._maybe_refresh_trust`` rolls the trust window forward while
+    the session is still healthy.
+
+    This is what makes a container restart survivable: icloudpy persists
+    the token ``trust_session`` mints, so refreshing on a schedule keeps
+    the copy on disk young. Without it a long-lived process can hold a
+    valid in-memory session for months while the persisted token quietly
+    expires, stranding the next cold start on a second factor.
+    """
+
+    def _expiry(self, days: int):
+        return datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
+            days=days,
+        )
+
+    def test_disabled_when_threshold_is_zero(self):
+        from src import sync
+
+        api = MagicMock()
+        cfg = {"app": {"trust_refresh_days": 0}}
+        with patch.object(sync, "_read_trust_cookie_expiry") as reader:
+            sync._maybe_refresh_trust(cfg, api)  # noqa: SLF001
+        reader.assert_not_called()
+        api.trust_session.assert_not_called()
+
+    def test_noop_when_no_trust_cookie(self):
+        """Never authenticated with 2FA, or the cookie was cleared."""
+        from src import sync
+
+        api = MagicMock()
+        with patch.object(sync, "_read_trust_cookie_expiry", return_value=None):
+            sync._maybe_refresh_trust({}, api)  # noqa: SLF001
+        api.trust_session.assert_not_called()
+
+    def test_noop_when_plenty_of_time_left(self):
+        from src import sync
+
+        api = MagicMock()
+        with patch.object(
+            sync,
+            "_read_trust_cookie_expiry",
+            return_value=self._expiry(25),
+        ):
+            sync._maybe_refresh_trust({}, api)  # noqa: SLF001
+        api.trust_session.assert_not_called()
+
+    def test_refreshes_when_inside_threshold(self):
+        from src import sync
+
+        api = MagicMock()
+        api.trust_session.return_value = True
+        with patch.object(
+            sync,
+            "_read_trust_cookie_expiry",
+            side_effect=[self._expiry(3), self._expiry(30)],
+        ):
+            sync._maybe_refresh_trust({}, api)  # noqa: SLF001
+        api.trust_session.assert_called_once()
+
+    def test_refresh_logs_when_apple_declines(self):
+        """A declined refresh is not fatal — it just means the next cold
+        start will need a second factor."""
+        from src import sync
+
+        api = MagicMock()
+        api.trust_session.return_value = False
+        with patch.object(
+            sync,
+            "_read_trust_cookie_expiry",
+            return_value=self._expiry(2),
+        ):
+            sync._maybe_refresh_trust({}, api)  # noqa: SLF001
+        api.trust_session.assert_called_once()
+
+    def test_refresh_handles_unknown_new_expiry(self):
+        """``trust_session`` succeeded but the cookie is unreadable after —
+        log 'unknown' rather than raising."""
+        from src import sync
+
+        api = MagicMock()
+        api.trust_session.return_value = True
+        with patch.object(
+            sync,
+            "_read_trust_cookie_expiry",
+            side_effect=[self._expiry(1), None],
+        ):
+            sync._maybe_refresh_trust({}, api)  # noqa: SLF001
+        api.trust_session.assert_called_once()
+
+    def test_never_raises_into_the_sync_loop(self):
+        from src import sync
+
+        api = MagicMock()
+        api.trust_session.side_effect = RuntimeError("apple down")
+        with patch.object(
+            sync,
+            "_read_trust_cookie_expiry",
+            return_value=self._expiry(1),
+        ):
+            sync._maybe_refresh_trust({}, api)  # noqa: SLF001


### PR DESCRIPTION
A long-running container holds an authenticated session in memory and never revalidates, so nothing notices the persisted trust token ageing out. The failure surfaces only at the next cold start — reboot, image pull, crash — which then needs a second factor for a container that had been syncing for months. One install ran 78 days that way and was locked out by an unrelated reboot.

`trust_session` mints a fresh `X-Apple-TwoSV-Trust-Token` whenever called on a live session, and icloudpy persists it. Calling it on a schedule keeps the on-disk copy young, so a cold start resumes without a factor.

Reads the remaining window from Apple's `X-APPLE-WEBAUTH-HSA-TRUST` cookie rather than assuming a duration, and refreshes when fewer than `app.trust_refresh_days` remain (default 14, `0` disables). Best-effort: a failed refresh is logged and syncing continues.

Complements the existing `trust_expiry_warn_days`, which warns the operator; this aims to make the warning unnecessary.