### PR TITLE
fix(web): stop reporting a healthy account while sync is stuck

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -94,6 +94,23 @@ def _resolve_dashboard_url(config) -> str | None:
     return f"http://{host}:{port}"
 
 
+def _publish_auth_blocked(blocked: bool, reason: str | None = None) -> None:
+    """Tell the web UI whether the loop can authenticate.
+
+    Only this loop knows: every on-disk signal the dashboard can check by
+    itself (username configured, password in the keyring) still looks
+    healthy while an account sits stuck on a second factor.
+
+    Best-effort -- signalling must never break syncing.
+    """
+    try:
+        from src import web_signals
+
+        web_signals.record_auth_blocked(blocked=blocked, reason=reason)
+    except Exception as e:  # pragma: no cover - signalling is advisory
+        LOGGER.warning(f"Could not publish auth state: {e!s}")
+
+
 def _maybe_warn_trust_expiring(config, api, username: str) -> None:
     """Fire the trust-expiring notification once when crossing threshold.
 
@@ -778,6 +795,7 @@ def _handle_2fa_required(config, username: str, sync_state: SyncState):
         bool: True if should continue (retry), False if should exit
     """
     LOGGER.error("Error: 2FA is required. Please log in.")
+    _publish_auth_blocked(True, reason="2fa_required")
     sleep_for = config_parser.get_retry_login_interval(config=config)
 
     if sleep_for < 0:
@@ -1019,6 +1037,7 @@ def sync(dry_run: bool = False, check_files: int | None = None):
                         _perform_dry_run(config, api, check_files=check_files)
                     return
 
+                _publish_auth_blocked(False)
                 if not api.requires_2sa:
                     # Trust-window check: record current cookie expiry and
                     # fire a pre-emptive warning once if it's about to lapse.

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -113,7 +113,10 @@
       .container { padding: 20px 16px 32px; }
       .header-inner { padding: 0 16px; gap: 12px; }
       .page-title { font-size: 26px; }
-      .page-sub { word-break: break-all; }
+      /* Break only words that genuinely cannot fit (long Apple IDs,
+         config paths, URLs). ``break-all`` split ordinary prose
+         mid-word on phones. */
+      .page-sub { overflow-wrap: anywhere; }
       .status-row { padding: 14px 16px; gap: 10px; }
       .status-text { flex-basis: 100%; }
       .status-actions { margin-left: 0; width: 100%; }

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -28,6 +28,14 @@
     <a class="status-cta" href="/auth">Re-authenticate</a>
   </div>
 </div>
+{% elif auth == 'reauth_needed' %}
+<div class="status-row">
+  <div class="status-dot err"></div>
+  <div class="status-text"><strong>{{ status.username }}</strong> — sync is stopped: Apple is asking for a second factor</div>
+  <div class="status-actions">
+    <a class="status-cta" href="/auth">Re-authenticate →</a>
+  </div>
+</div>
 {% elif auth == 'setup_needed' %}
 <div class="status-row">
   <div class="status-dot warn"></div>
@@ -36,7 +44,7 @@
     <a class="status-cta" href="/auth">Authenticate now →</a>
   </div>
 </div>
-{% else %}
+{% elif auth == 'not_configured' %}
 <div class="status-row">
   <div class="status-dot warn"></div>
   <div class="status-text">No <strong>app.credentials.username</strong> in config.yaml</div>

--- a/src/web.py
+++ b/src/web.py
@@ -368,6 +368,9 @@ def _detect_auth_state(username: str | None) -> str:
       - ``not_configured`` — no ``app.credentials.username`` in config.
       - ``setup_needed`` — username set, but the keyring has no password
         cached. The container's first 2FA flow hasn't been completed.
+      - ``reauth_needed`` — the sync loop reported that it cannot
+        authenticate. Every on-disk signal below looks fine in this state,
+        which is why it has to be asked for explicitly.
       - ``ready`` — username set + keyring entry present. Sync loop can
         resume the session on the next retry.
 
@@ -381,6 +384,12 @@ def _detect_auth_state(username: str | None) -> str:
         from icloudpy import utils as icloudpy_utils
 
         if icloudpy_utils.password_exists_in_keyring(username):
+            # Ask the sync loop before claiming health: a configured
+            # username and a cached password look identical whether or not
+            # Apple is demanding a second factor, so on-disk signals alone
+            # render a green dashboard over a sync that has not run.
+            if web_signals.get_auth_blocked().get("blocked"):
+                return "reauth_needed"
             return "ready"
     except Exception as e:
         LOGGER.debug(f"Web UI auth-state check raised: {e!s}")

--- a/src/web_signals.py
+++ b/src/web_signals.py
@@ -187,6 +187,7 @@ def _save_state(state: dict[str, dict[str, Any]]) -> None:
 
 
 _TRUST_STATE_KEY = "_trust"
+_AUTH_BLOCKED_STATE_KEY = "_auth_blocked"
 
 
 def record_trust_state(
@@ -216,6 +217,30 @@ def record_trust_state(
 def get_trust_state() -> dict[str, Any]:
     """Return persisted trust state. Empty dict if never recorded."""
     return _load_state().get(_TRUST_STATE_KEY, {})
+
+
+def record_auth_blocked(*, blocked: bool, reason: str | None = None) -> None:
+    """Record whether the sync loop is currently unable to authenticate.
+
+    ``_detect_auth_state`` can only see on-disk signals -- a username in
+    the config and a password in the keyring -- so it reports "ready" for
+    an account that is in fact stuck on a second factor. Only the sync
+    loop knows it is failing, so it publishes that here and the dashboard
+    stops claiming everything is healthy while nothing is syncing.
+    """
+    state = _load_state()
+    state[_AUTH_BLOCKED_STATE_KEY] = {
+        "blocked": bool(blocked),
+        "reason": reason,
+        "last_updated": time.time(),
+    }
+    _save_state(state)
+
+
+def get_auth_blocked() -> dict[str, Any]:
+    """Return the recorded auth-blocked state. Empty dict if never recorded."""
+    entry = _load_state().get(_AUTH_BLOCKED_STATE_KEY)
+    return entry if isinstance(entry, dict) else {}
 
 
 def format_relative_time(epoch_seconds: float, *, now: float | None = None) -> str:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1380,3 +1380,56 @@ class TestPendingAuthTtl(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAuthStateReflectsSyncLoop(unittest.TestCase):
+    """``_detect_auth_state`` must not report health the sync loop is
+    contradicting: a green dashboard over a sync that stopped weeks ago is
+    worse than no dashboard."""
+
+    def test_reauth_needed_when_the_loop_reports_blocked(self):
+        with (
+            patch("icloudpy.utils.password_exists_in_keyring", return_value=True),
+            patch("src.web_signals.get_auth_blocked", return_value={"blocked": True}),
+        ):
+            self.assertEqual(
+                web._detect_auth_state(username="a@icloud.com"),  # noqa: SLF001
+                "reauth_needed",
+            )
+
+    def test_ready_when_the_loop_reports_healthy(self):
+        with (
+            patch("icloudpy.utils.password_exists_in_keyring", return_value=True),
+            patch("src.web_signals.get_auth_blocked", return_value={"blocked": False}),
+        ):
+            self.assertEqual(
+                web._detect_auth_state(username="a@icloud.com"),  # noqa: SLF001
+                "ready",
+            )
+
+    def test_setup_needed_still_wins_without_a_keyring_entry(self):
+        with patch("icloudpy.utils.password_exists_in_keyring", return_value=False):
+            self.assertEqual(
+                web._detect_auth_state(username="a@icloud.com"),  # noqa: SLF001
+                "setup_needed",
+            )
+
+
+class TestSyncPublishesAuthState(unittest.TestCase):
+    """``sync._publish_auth_blocked`` is advisory and must never raise."""
+
+    def test_publishes_blocked(self):
+        from src import sync
+
+        with patch("src.web_signals.record_auth_blocked") as recorder:
+            sync._publish_auth_blocked(True, reason="2fa_required")  # noqa: SLF001
+        recorder.assert_called_once_with(blocked=True, reason="2fa_required")
+
+    def test_swallows_failure(self):
+        from src import sync
+
+        with patch(
+            "src.web_signals.record_auth_blocked",
+            side_effect=OSError("read-only"),
+        ):
+            sync._publish_auth_blocked(False)  # noqa: SLF001

--- a/tests/test_web_signals.py
+++ b/tests/test_web_signals.py
@@ -256,3 +256,40 @@ class TestFormatRelativeTime(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAuthBlockedState(unittest.TestCase):
+    """``record_auth_blocked`` / ``get_auth_blocked``.
+
+    The dashboard cannot infer this: a username in the config and a
+    password in the keyring both look correct while an account is stuck on
+    a second factor, so only the sync loop can report it."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._patcher = patch.object(web_signals, "_config_dir", return_value=self.tmp)
+        self._patcher.start()
+        self.addCleanup(self._patcher.stop)
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_unrecorded_is_empty(self):
+        self.assertEqual(web_signals.get_auth_blocked(), {})
+
+    def test_records_blocked_with_reason(self):
+        web_signals.record_auth_blocked(blocked=True, reason="2fa_required")
+        entry = web_signals.get_auth_blocked()
+        self.assertTrue(entry["blocked"])
+        self.assertEqual(entry["reason"], "2fa_required")
+
+    def test_clearing_unblocks(self):
+        web_signals.record_auth_blocked(blocked=True, reason="2fa_required")
+        web_signals.record_auth_blocked(blocked=False)
+        self.assertFalse(web_signals.get_auth_blocked()["blocked"])
+
+    def test_malformed_entry_is_empty(self):
+        web_signals._save_state({web_signals._AUTH_BLOCKED_STATE_KEY: "oops"})  # noqa: SLF001
+        self.assertEqual(web_signals.get_auth_blocked(), {})


### PR DESCRIPTION
The dashboard derives auth state from on-disk signals only — a username in `config.yaml` and a password in the keyring. Both look correct while Apple is demanding a second factor, so it shows `keyring populated, sync loop authenticated` over a sync that has not run for weeks.

Only the loop knows it is failing. It now publishes that through `web_signals`, adding a `reauth_needed` state that says sync is stopped and links to the auth page. Best-effort: a signalling failure is logged and syncing continues.

Also fixes `word-break: break-all` on `.page-sub` at the `<=560px` breakpoint. It splits every word at an arbitrary character rather than only those that cannot fit, so the config path and auth subtitle render as ragged mid-word fragments on a phone. `overflow-wrap: anywhere` keeps long Apple IDs and paths breaking without touching ordinary prose.