### PR TITLE
fix(web): add missing csrf_token to first-run auth form

### DIFF
--- a/src/templates/auth.html
+++ b/src/templates/auth.html
@@ -74,6 +74,7 @@
     </form>
   {% else %}
     <form method="post" action="/auth/password">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
       {% if status.username %}
       <div style="margin-bottom: 16px;">
         <label style="display: block; font-size: 13px; color: var(--text-secondary); margin-bottom: 6px; font-weight: 500;">Apple ID</label>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -356,6 +356,7 @@ class TestAuthForm(unittest.TestCase):
         body = client.get("/auth").data.decode("utf-8")
         self.assertIn('name="password"', body)
         self.assertIn('action="/auth/password"', body)
+        self.assertIn('name="csrf_token" value="', body)
 
     def test_auth_renders_code_field_when_pending(self):
         with web._AUTH_LOCK:  # noqa: SLF001


### PR DESCRIPTION
## Summary
When using the web ui to do the first authentication on startup (the `{% else %}` branch of `src/templates/auth.html`,
shown when the keyring has no stored password) the initial authentication POST fails with a 403 `CSRF token mismatch` due to a missing `csrf_token` input.

## Reproduce
1. Fresh container with empty `/config/python_keyring`
2. Open the web UI auth page (`/auth`)
3. Submit the password form -> `{"error":"CSRF token mismatch"}` (403)

## Fix
Add missing `<input type="hidden" name="csrf_token" value="{{ csrf_token }}">`

## Testing
- Regression assertion added to `TestAuthForm.test_auth_renders_password_field_when_no_pending`
  asserting the first-run render embeds `name="csrf_token"`.
- Manual test verifying I can login on first launch.