### PR TITLE
fix(photos): one unreadable library must not stop the others

### DIFF
--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -8,6 +8,9 @@ ___author___ = "Mandar Patil <mandarons@pm.me>"
 
 import os
 
+import requests
+from icloudpy import exceptions
+
 from src import config_parser, configure_icloudpy_logging, get_logger
 from src.album_sync_orchestrator import sync_album_photos
 from src.hardlink_registry import create_hardlink_registry
@@ -397,6 +400,11 @@ def sync_photos(config, photos):
     hardlink_registry = create_hardlink_registry(use_hardlinks)
 
     total_successful, total_failed = 0, 0
+    # Libraries we could not read. They must be barred from the cleanup
+    # below: a library that failed contributes nothing to ``files``, so
+    # cleaning its destination would read as "the server has none of these"
+    # and delete every local copy.
+    failed_libraries: set = set()
 
     # Special handling for "All Photos" when hardlinks are enabled
     if use_hardlinks and download_all:
@@ -410,6 +418,7 @@ def sync_photos(config, photos):
             hardlink_registry,
             config,
             library_destinations=library_destinations,
+            failed_libraries=failed_libraries,
         )
         total_successful += sub_successful
         total_failed += sub_failed
@@ -426,6 +435,7 @@ def sync_photos(config, photos):
         hardlink_registry,
         config,
         library_destinations=library_destinations,
+        failed_libraries=failed_libraries,
     )
     total_successful += sub_successful
     total_failed += sub_failed
@@ -438,8 +448,22 @@ def sync_photos(config, photos):
         exclude = {marker_filename}
         if library_destinations:
             for library in libraries:
+                if library in failed_libraries:
+                    LOGGER.warning(
+                        f"Skipping obsolete-file cleanup for {library}: it could not "
+                        f"be read this run, so its local files cannot be verified.",
+                    )
+                    continue
                 lib_dest = _library_destination(destination_path, library, library_destinations)
                 remove_obsolete_files(lib_dest, files, exclude_filenames=exclude)
+        elif failed_libraries:
+            # One shared destination: ``files`` cannot say which library a
+            # path came from, so a single failure makes the whole set
+            # untrustworthy for deletion.
+            LOGGER.warning(
+                "Skipping obsolete-file cleanup: "
+                f"{len(failed_libraries)} library(ies) could not be read this run.",
+            )
         else:
             remove_obsolete_files(destination_path, files, exclude_filenames=exclude)
 
@@ -483,6 +507,25 @@ def _library_destination(base_destination: str, library: str, library_destinatio
     return dest
 
 
+# An account can be shown libraries it never created -- zones left behind
+# by Apple's own backend migrations -- and some of them answer every query
+# with ZONE_NOT_FOUND or BAD_REQUEST. One of those must not be able to
+# abort the sync for the libraries that work.
+_LIBRARY_FAULTS = (exceptions.ICloudPyAPIResponseException, requests.exceptions.RequestException)
+
+
+def _note_library_failure(library, error, failed_libraries) -> None:
+    """Record a library we could not read, and say so in the log.
+
+    Never silent: the count is reported as failures by the caller, and the
+    library is barred from obsolete-file cleanup so an unreadable library
+    can never be mistaken for an empty one.
+    """
+    LOGGER.error(f"Library {library} could not be synced, skipping it: {error!s}")
+    if failed_libraries is not None:
+        failed_libraries.add(library)
+
+
 def _sync_all_photos_first_for_hardlinks(
     photos,
     libraries,
@@ -493,6 +536,7 @@ def _sync_all_photos_first_for_hardlinks(
     hardlink_registry,
     config,
     library_destinations: dict | None = None,
+    failed_libraries: set | None = None,
 ) -> tuple[int, int]:
     """Sync 'All Photos' album first to populate hardlink registry.
 
@@ -510,27 +554,30 @@ def _sync_all_photos_first_for_hardlinks(
         Tuple of (total_successful, total_failed) download counts
     """
     for library in libraries:
-        if library == "PrimarySync" and "All Photos" in photos.libraries[library].albums:
-            LOGGER.info("Syncing 'All Photos' album first for hard link reference...")
-            lib_dest = _library_destination(destination_path, library, library_destinations or {})
-            result = sync_album_photos(
-                album=photos.libraries[library].albums["All Photos"],
-                destination_path=os.path.join(lib_dest, "All Photos"),
-                file_sizes=filters["file_sizes"],
-                extensions=filters["extensions"],
-                files=files,
-                folder_format=folder_format,
-                hardlink_registry=hardlink_registry,
-                config=config,
-            )
-            if hardlink_registry:
-                LOGGER.info(
-                    f"'All Photos' sync complete. Hard link registry populated with "
-                    f"{hardlink_registry.get_registry_size()} reference files.",
+        try:
+            if library == "PrimarySync" and "All Photos" in photos.libraries[library].albums:
+                LOGGER.info("Syncing 'All Photos' album first for hard link reference...")
+                lib_dest = _library_destination(destination_path, library, library_destinations or {})
+                result = sync_album_photos(
+                    album=photos.libraries[library].albums["All Photos"],
+                    destination_path=os.path.join(lib_dest, "All Photos"),
+                    file_sizes=filters["file_sizes"],
+                    extensions=filters["extensions"],
+                    files=files,
+                    folder_format=folder_format,
+                    hardlink_registry=hardlink_registry,
+                    config=config,
                 )
-            if result is not None:
-                return result
-            break
+                if hardlink_registry:
+                    LOGGER.info(
+                        f"'All Photos' sync complete. Hard link registry populated with "
+                        f"{hardlink_registry.get_registry_size()} reference files.",
+                    )
+                if result is not None:
+                    return result
+                break
+        except _LIBRARY_FAULTS as e:
+            _note_library_failure(library, e, failed_libraries)
     return 0, 0
 
 
@@ -545,6 +592,7 @@ def _sync_albums_by_configuration(
     hardlink_registry,
     config,
     library_destinations: dict | None = None,
+    failed_libraries: set | None = None,
 ) -> tuple[int, int]:
     """Sync albums based on configuration settings.
 
@@ -564,53 +612,58 @@ def _sync_albums_by_configuration(
     """
     total_successful, total_failed = 0, 0
     for library in libraries:
-        lib_dest = _library_destination(destination_path, library, library_destinations or {})
-        if download_all and library == "PrimarySync":
-            sub_successful, sub_failed = _sync_all_albums_except_filtered(
-                photos,
-                library,
-                filters,
-                lib_dest,
-                files,
-                folder_format,
-                hardlink_registry,
-                config,
-            )
-        elif filters["albums"] and library == "PrimarySync":
-            sub_successful, sub_failed = _sync_filtered_albums(
-                photos,
-                library,
-                filters,
-                lib_dest,
-                files,
-                folder_format,
-                hardlink_registry,
-                config,
-            )
-        elif filters["albums"]:
-            sub_successful, sub_failed = _sync_filtered_albums_in_library(
-                photos,
-                library,
-                filters,
-                lib_dest,
-                files,
-                folder_format,
-                hardlink_registry,
-                config,
-            )
-        else:
-            sub_successful, sub_failed = _sync_all_photos_in_library(
-                photos,
-                library,
-                lib_dest,
-                filters,
-                files,
-                folder_format,
-                hardlink_registry,
-                config,
-            )
-        total_successful += sub_successful
-        total_failed += sub_failed
+        try:
+            lib_dest = _library_destination(destination_path, library, library_destinations or {})
+            if download_all and library == "PrimarySync":
+                sub_successful, sub_failed = _sync_all_albums_except_filtered(
+                    photos,
+                    library,
+                    filters,
+                    lib_dest,
+                    files,
+                    folder_format,
+                    hardlink_registry,
+                    config,
+                )
+            elif filters["albums"] and library == "PrimarySync":
+                sub_successful, sub_failed = _sync_filtered_albums(
+                    photos,
+                    library,
+                    filters,
+                    lib_dest,
+                    files,
+                    folder_format,
+                    hardlink_registry,
+                    config,
+                )
+            elif filters["albums"]:
+                sub_successful, sub_failed = _sync_filtered_albums_in_library(
+                    photos,
+                    library,
+                    filters,
+                    lib_dest,
+                    files,
+                    folder_format,
+                    hardlink_registry,
+                    config,
+                )
+            else:
+                sub_successful, sub_failed = _sync_all_photos_in_library(
+                    photos,
+                    library,
+                    lib_dest,
+                    filters,
+                    files,
+                    folder_format,
+                    hardlink_registry,
+                    config,
+                )
+            total_successful += sub_successful
+            total_failed += sub_failed
+        # Per-iteration by design: isolating one library from the next is
+        # the whole point, so the handler cannot be hoisted out of the loop.
+        except _LIBRARY_FAULTS as e:  # noqa: PERF203
+            _note_library_failure(library, e, failed_libraries)
     return total_successful, total_failed
 
 

--- a/src/sync_photos.py
+++ b/src/sync_photos.py
@@ -455,6 +455,19 @@ def sync_photos(config, photos):
                     )
                     continue
                 lib_dest = _library_destination(destination_path, library, library_destinations)
+                if lib_dest == destination_path:
+                    # An unmapped library falls through to the shared root,
+                    # which holds every other library's tree -- and anything
+                    # else the user keeps there. Cleaning it on behalf of one
+                    # library would delete all of them. Apple invents
+                    # libraries (backend migration zones), so this is reached
+                    # by doing nothing wrong.
+                    LOGGER.warning(
+                        f"Skipping obsolete-file cleanup for {library}: it has no "
+                        f"library_destinations entry, so its destination is the "
+                        f"shared root and cleaning it would affect other libraries.",
+                    )
+                    continue
                 remove_obsolete_files(lib_dest, files, exclude_filenames=exclude)
         elif failed_libraries:
             # One shared destination: ``files`` cannot say which library a
@@ -483,7 +496,7 @@ def _library_destination(base_destination: str, library: str, library_destinatio
     1. **Exact match.** ``library_destinations[library]`` if present.
     2. **Role alias for `SharedLibrary`.** Apple's modern iCloud Shared
        Photo Library is exposed by icloudpy under a GUID-based zone name
-       like ``SharedSync-3C977B4A-C15A-46E4-9854-585B9342C409``. A config
+       like ``SharedSync-<guid>``. A config
        key of ``SharedLibrary`` matches any zone whose name starts with
        ``SharedSync-`` so users don't need to discover and hardcode the
        per-account GUID. (Configs that already use the literal current

--- a/tests/test_library_destinations.py
+++ b/tests/test_library_destinations.py
@@ -85,12 +85,12 @@ class TestLibraryDestinationHelper(unittest.TestCase):
 
     def test_shared_library_alias_matches_guid_named_zone(self):
         """`SharedLibrary` in the config matches Apple's GUID-named shared zones
-        (e.g. ``SharedSync-3C977B4A-...``) — users don't have to discover and
+        (e.g. ``SharedSync-<guid>``) — users don't have to discover and
         hardcode their per-account GUID."""
         with tempfile.TemporaryDirectory() as base:
-            mapping = {"PrimarySync": "Eric", "SharedLibrary": "Shared"}
+            mapping = {"PrimarySync": "Personal", "SharedLibrary": "Shared"}
             result = _library_destination(
-                base, "SharedSync-3C977B4A-C15A-46E4-9854-585B9342C409", mapping,
+                base, "SharedSync-00000000-0000-4000-8000-000000000000", mapping,
             )
             assert result == os.path.join(base, "Shared")
             assert os.path.isdir(result)
@@ -100,7 +100,7 @@ class TestLibraryDestinationHelper(unittest.TestCase):
         a non-SharedSync library that isn't explicitly mapped still falls
         through to base."""
         with tempfile.TemporaryDirectory() as base:
-            mapping = {"PrimarySync": "Eric", "SharedLibrary": "Shared"}
+            mapping = {"PrimarySync": "Personal", "SharedLibrary": "Shared"}
             result = _library_destination(base, "OtherLibrary", mapping)
             assert result == base
 

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -5,6 +5,7 @@ __author__ = "Mandar Patil (mandarons@pm.me)"
 import glob
 import os
 import shutil
+import tempfile
 import unittest
 from datetime import timezone
 from io import StringIO
@@ -2570,3 +2571,146 @@ class TestSyncPhotos(unittest.TestCase):
             )
         # Should return (0, 0) when sync_album_photos returns None
         self.assertEqual(result, (0, 0))
+
+
+class TestBrokenLibraryDoesNotStopTheOthers(unittest.TestCase):
+    """An account can be shown libraries it never created -- zones left
+    behind by Apple's own backend migrations -- and some answer every query
+    with ZONE_NOT_FOUND or BAD_REQUEST. One of those used to abort the whole
+    photos pass, so libraries later in the list never synced at all."""
+
+    def _photos(self, names):
+        from unittest.mock import MagicMock
+
+        photos = MagicMock()
+        photos.libraries = {n: MagicMock() for n in names}
+        return photos
+
+    def test_a_failing_library_does_not_prevent_the_next_one(self):
+        from unittest.mock import patch
+
+        from icloudpy import exceptions
+
+        from src import sync_photos
+
+        seen = []
+
+        def fake(photos, library, *a, **k):
+            seen.append(library)
+            if library.startswith("BrokenZone"):
+                msg = "ZONE_NOT_FOUND"
+                raise exceptions.ICloudPyServiceNotActivatedException(msg)
+            return (5, 0)
+
+        failed = set()
+        with patch.object(sync_photos, "_sync_all_photos_in_library", side_effect=fake):
+            ok, bad = sync_photos._sync_albums_by_configuration(  # noqa: SLF001
+                self._photos(["SharedSync-A", "BrokenZone-1", "PrimarySync"]),
+                ["SharedSync-A", "BrokenZone-1", "PrimarySync"],
+                False,
+                "/dest",
+                {"albums": None, "file_sizes": ["original"], "extensions": None},
+                set(),
+                "%Y/%m",
+                None,
+                {},
+                failed_libraries=failed,
+            )
+        # PrimarySync is last; before the fix it was never reached.
+        self.assertEqual(seen, ["SharedSync-A", "BrokenZone-1", "PrimarySync"])
+        self.assertEqual(ok, 10)
+        self.assertEqual(failed, {"BrokenZone-1"})
+
+    def test_a_failed_library_is_never_cleaned_up(self):
+        """The data-loss guard: a library that could not be read contributes
+        nothing to ``files``, so cleaning it would delete every local copy."""
+        from unittest.mock import patch
+
+        from src import sync_photos
+
+        cleaned = []
+        tmp = tempfile.mkdtemp()
+        cfg = {
+            "app": {"root": "/icloud"},
+            "photos": {
+                "destination": "photos",
+                "remove_obsolete": True,
+                "library_destinations": {"PrimarySync": "Personal", "Broken": "Shared"},
+            },
+        }
+
+        def fake_albums(*a, **k):
+            k["failed_libraries"].add("Broken")
+            return (1, 0)
+
+        with (
+            patch.object(sync_photos, "_sync_albums_by_configuration", side_effect=fake_albums),
+            patch.object(sync_photos, "remove_obsolete_files", side_effect=lambda d, f, **k: cleaned.append(d)),
+            patch.object(sync_photos.config_parser, "prepare_photos_destination", return_value=tmp),
+        ):
+            sync_photos.sync_photos(config=cfg, photos=self._photos(["PrimarySync", "Broken"]))
+
+        self.assertTrue(any("Personal" in c for c in cleaned), "healthy library should still be cleaned")
+        self.assertFalse(any("Shared" in c for c in cleaned), "failed library must never be cleaned")
+
+    def test_shared_destination_skips_cleanup_entirely_on_any_failure(self):
+        """Without per-library destinations, ``files`` cannot attribute a path
+        to a library, so one failure makes the whole set unusable."""
+        from unittest.mock import patch
+
+        from src import sync_photos
+
+        cleaned = []
+        tmp = tempfile.mkdtemp()
+        cfg = {
+            "app": {"root": "/icloud"},
+            "photos": {"destination": "photos", "remove_obsolete": True},
+        }
+
+        def fake_albums(*a, **k):
+            k["failed_libraries"].add("Broken")
+            return (1, 0)
+
+        with (
+            patch.object(sync_photos, "_sync_albums_by_configuration", side_effect=fake_albums),
+            patch.object(sync_photos, "remove_obsolete_files", side_effect=lambda d, f, **k: cleaned.append(d)),
+            patch.object(sync_photos.config_parser, "prepare_photos_destination", return_value=tmp),
+        ):
+            sync_photos.sync_photos(config=cfg, photos=self._photos(["PrimarySync", "Broken"]))
+
+        self.assertEqual(cleaned, [], "a failure must disable cleanup for the shared destination")
+
+    def test_hardlink_pass_survives_a_broken_library(self):
+        """The 'All Photos' pre-pass walks libraries too, so it needs the
+        same isolation -- otherwise a library that faults mid-album kills the
+        run before the main album sync ever starts."""
+        from unittest.mock import MagicMock, patch
+
+        from icloudpy import exceptions
+
+        from src import sync_photos
+
+        photos = MagicMock()
+        lib = MagicMock()
+        lib.albums = {"All Photos": MagicMock()}
+        photos.libraries = {"PrimarySync": lib}
+
+        error = exceptions.ICloudPyAPIResponseException("Index has invalid data")
+        failed = set()
+        with (
+            patch.object(sync_photos, "sync_album_photos", side_effect=error),
+            patch.object(sync_photos, "_library_destination", return_value="/dest"),
+        ):
+            ok, bad = sync_photos._sync_all_photos_first_for_hardlinks(  # noqa: SLF001
+                photos,
+                ["PrimarySync"],
+                "/dest",
+                {"file_sizes": ["original"], "extensions": None},
+                set(),
+                "%Y/%m",
+                None,
+                {},
+                failed_libraries=failed,
+            )
+        self.assertEqual((ok, bad), (0, 0))
+        self.assertEqual(failed, {"PrimarySync"})

--- a/tests/test_sync_photos.py
+++ b/tests/test_sync_photos.py
@@ -2714,3 +2714,33 @@ class TestBrokenLibraryDoesNotStopTheOthers(unittest.TestCase):
             )
         self.assertEqual((ok, bad), (0, 0))
         self.assertEqual(failed, {"PrimarySync"})
+
+    def test_an_unmapped_library_never_cleans_the_shared_root(self):
+        """A library with no library_destinations entry falls through to the
+        photos root, which holds every other library's tree. Cleaning it on
+        that library's behalf would delete all of them -- including trees
+        this container does not own."""
+        from unittest.mock import patch
+
+        from src import sync_photos
+
+        cleaned = []
+        tmp = tempfile.mkdtemp()
+        cfg = {
+            "app": {"root": "/icloud"},
+            "photos": {
+                "destination": "photos",
+                "remove_obsolete": True,
+                # NewZone deliberately absent from the mapping.
+                "library_destinations": {"PrimarySync": "Personal"},
+            },
+        }
+        with (
+            patch.object(sync_photos, "_sync_albums_by_configuration", return_value=(1, 0)),
+            patch.object(sync_photos, "remove_obsolete_files", side_effect=lambda d, f, **k: cleaned.append(d)),
+            patch.object(sync_photos.config_parser, "prepare_photos_destination", return_value=tmp),
+        ):
+            sync_photos.sync_photos(config=cfg, photos=self._photos(["PrimarySync", "NewZone"]))
+
+        self.assertTrue(any("Personal" in c for c in cleaned), "mapped library still cleaned")
+        self.assertNotIn(tmp, cleaned, "the shared root must never be cleaned per-library")


### PR DESCRIPTION
An account can be shown libraries it never created — zones left behind by Apple's own backend migrations — and some of them answer every query with `ZONE_NOT_FOUND` or `BAD_REQUEST`. The library loop had no error handling, so one of those aborted the entire photos pass and every library after it in the list never synced.

Seen on a real account: the primary library stopped syncing for weeks while a library processed earlier kept working, with nothing on the dashboard to show it, because a completion is only recorded when the whole pass finishes.

Each library is now isolated — the fault is logged, the library recorded, and the sync continues.

That makes `photos.remove_obsolete` dangerous, so this change guards it in the same commit series. Cleanup deletes any local file absent from the set of files seen during the run, and a library that failed contributes nothing to that set — so continuing past a failure would read as "the server has none of these" and delete every local copy.

- A library that failed this run is excluded from cleanup. When a single shared destination is configured, one failure disables cleanup entirely, because the file set cannot attribute a path to a library.
- Cleanup never runs against the base destination. A library with no `library_destinations` entry falls through to it by design, so per-library cleanup walked the shared photos root — which holds every other library's tree. One unmapped library would have deleted all of them, and since Apple adds libraries to an account on its own, a mapping that was complete when written silently stops being complete.

Suite at 100% coverage.
